### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "promises-tests": "promises-aplus-tests tests/promises_tests_adapter"
   },
+  "license": "MIT",
   "keywords": [
     "ES6",
     "ECMAScript 6",


### PR DESCRIPTION
Looks like it was in `bower.json` but not `package.json`.