### PR TITLE
Fix bower.json Format

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,10 +18,14 @@
     "console"
   ],
   "authors": [
-    "zloirock.ru"
+    "Denis Pushkarev <zloirock@zloirock.ru> (http://zloirock.ru/)"
   ],
   "license": "MIT",
-  "homepage": "github.com/zloirock/core-js",
+  "homepage": "https://github.com/zloirock/core-js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zloirock/core-js.git"
+  },
   "ignore": [
     "build",
     "node_modules",


### PR DESCRIPTION
This fixes some issues with the bower.json:
* authors has wrong format
* homepage has wrong format (missing scheme)
* added repository info

More info: https://github.com/bower/bower.json-spec

The malformed homepage url currently breaks packaging with https://rails-assets.org.