### PR TITLE
fixed $.task for IE11 (had a missing context)

### DIFF
--- a/modules/$.task.js
+++ b/modules/$.task.js
@@ -31,7 +31,7 @@ if(!isFunction(setTask) || !isFunction(clearTask)){
     var args = [], i = 1;
     while(arguments.length > i)args.push(arguments[i++]);
     queue[++counter] = function(){
-      invoke(isFunction(fn) ? fn : Function(fn), args);
+      invoke(isFunction(fn) ? fn : Function(fn), args, global);
     };
     defer(counter);
     return counter;


### PR DESCRIPTION
IE11 threw a `Invalid Calling Object` error because `setImmediate` was called without `window` as context.