### PR TITLE
Fix strict mode when testing with PhantomJS 1.x.

### DIFF
--- a/build/build.ls
+++ b/build/build.ls
@@ -97,6 +97,7 @@ module.exports = ({modules, blacklist, library}, next)-> let @ = modules.turn ((
   next """
     #banner
     !function(undefined){
+    'use strict';
     var __e = null, __g = null;
     
     #script

--- a/tests/tests/es6.array.copy-within.ls
+++ b/tests/tests/es6.array.copy-within.ls
@@ -19,7 +19,7 @@ test '*' !->
   deq [1 2 3 4 5]copyWithin(-4 -3 -2), [1 3 3 4 5]
   deq [1 2 3 4 5]copyWithin(-4 -3 -1), [1 3 4 4 5]
   deq [1 2 3 4 5]copyWithin(-4 -3), [1 3 4 5 5]
-  if (-> @).call(void) is void and not /PhantomJS/.test window?navigator?userAgent
+  if (-> @).call(void) is void
     throws (-> Array::copyWithin.call null, 0), TypeError
     throws (-> Array::copyWithin.call void, 0), TypeError
   ok \copyWithin of Array::[Symbol.unscopables], 'In Array#@@unscopables'

--- a/tests/tests/es6.array.fill.ls
+++ b/tests/tests/es6.array.fill.ls
@@ -12,7 +12,7 @@ test '*' !->
   deq Array(5)fill(5 1 4), [void 5 5 5 void]
   deq Array(5)fill(5 6 1), [void void void void void]
   deq Array(5)fill(5 -3 4), [void void 5 5 void]
-  if (-> @).call(void) is void and not /PhantomJS/.test window?navigator?userAgent
+  if (-> @).call(void) is void
     throws (-> Array::fill.call null, 0), TypeError
     throws (-> Array::fill.call void, 0), TypeError
   ok \fill of Array::[Symbol.unscopables], 'In Array#@@unscopables'

--- a/tests/tests/es6.object.to-string.ls
+++ b/tests/tests/es6.object.to-string.ls
@@ -6,7 +6,7 @@ eq = strictEqual
 
 test 'Object#toString' !->
   {toString} = Object::
-  if (-> @).call(void) is void and not /PhantomJS/.test window?navigator?userAgent
+  if (-> @).call(void) is void
     eq toString.call(null), '[object Null]', 'classof null is `Null`'
     eq toString.call(void), '[object Undefined]', 'classof void is `Undefined`'
   eq toString.call(true), '[object Boolean]', 'classof bool is `Boolean`'

--- a/tests/tests/es6.string.code-point-at.ls
+++ b/tests/tests/es6.string.code-point-at.ls
@@ -56,6 +56,6 @@ test '*' !->
   eq '\uDF06abc'codePointAt(NaN), 0xDF06
   eq '\uDF06abc'codePointAt(null), 0xDF06
   eq '\uDF06abc'codePointAt(void), 0xDF06
-  if (-> @).call(void) is void and not /PhantomJS/.test window?navigator?userAgent
+  if (-> @).call(void) is void
     throws (-> String::codePointAt.call null, 0), TypeError
     throws (-> String::codePointAt.call void, 0), TypeError

--- a/tests/tests/es6.string.ends-with.ls
+++ b/tests/tests/es6.string.ends-with.ls
@@ -17,7 +17,7 @@ test '*' !->
   ok 'abc'endsWith \a on
   ok not 'abc'endsWith \c \x
   ok not 'abc'endsWith \a \x
-  if (-> @).call(void) is void and not /PhantomJS/.test window?navigator?userAgent
+  if (-> @).call(void) is void
     throws (-> String::endsWith.call null, '.'), TypeError
     throws (-> String::endsWith.call void, '.'), TypeError
   throws (-> 'qwe'endsWith /./), TypeError

--- a/tests/tests/es6.string.includes.ls
+++ b/tests/tests/es6.string.includes.ls
@@ -8,7 +8,7 @@ test '*' !->
   ok 'aundefinedb'includes!
   ok 'abcd'includes \b 1
   ok not 'abcd'includes \b 2
-  if (-> @).call(void) is void and not /PhantomJS/.test window?navigator?userAgent
+  if (-> @).call(void) is void
     throws (-> String::includes.call null, '.'), TypeError
     throws (-> String::includes.call void, '.'), TypeError
   throws (-> 'foo[a-z]+(bar)?'includes /[a-z]+/), TypeError

--- a/tests/tests/es6.string.repeat.ls
+++ b/tests/tests/es6.string.repeat.ls
@@ -10,6 +10,6 @@ test '*' !->
   eq 'qwe'repeat(2.5), \qweqwe
   throws (-> 'qwe'repeat -1), RangeError
   throws (-> 'qwe'repeat Infinity), RangeError
-  if (-> @).call(void) is void and not /PhantomJS/.test window?navigator?userAgent
+  if (-> @).call(void) is void
     throws (-> String::repeat.call null, 1), TypeError
     throws (-> String::repeat.call void, 1), TypeError

--- a/tests/tests/es6.string.starts-with.ls
+++ b/tests/tests/es6.string.starts-with.ls
@@ -16,7 +16,7 @@ test '*' !->
   ok not 'abc'startsWith \a Infinity
   ok 'abc'startsWith \b on
   ok 'abc'startsWith \a \x
-  if (-> @).call(void) is void and not /PhantomJS/.test window?navigator?userAgent
+  if (-> @).call(void) is void
     throws (-> String::startsWith.call null, '.'), TypeError
     throws (-> String::startsWith.call void, '.'), TypeError
   throws (-> 'qwe'startsWith /./), TypeError

--- a/tests/tests/es7.array.includes.ls
+++ b/tests/tests/es7.array.includes.ls
@@ -14,7 +14,7 @@ test '*' !->
   ok !arr.includes {}
   ok Array(1)includes void
   ok [NaN].includes(NaN)
-  if typeof (-> @).call(void) is \undefined and not /PhantomJS/.test window?navigator?userAgent
-    throws (-> Array::includes.call null, 0), TypeError, 'strict mode, null'
-    throws (-> Array::includes.call void, 0), TypeError, 'strict mode, undefined'
+  if typeof (-> @).call(void) is \undefined
+    throws (-> Array::includes.call null, 0), TypeError
+    throws (-> Array::includes.call void, 0), TypeError
   ok \includes of Array::[Symbol.unscopables], 'In Array#@@unscopables'

--- a/tests/tests/es7.string.at.ls
+++ b/tests/tests/es7.string.at.ls
@@ -90,6 +90,6 @@ test '*' !->
   eq at.call(42 1), \2
   eq at.call({toString: -> \abc}, 2), \c
   
-  if typeof (-> @).call(void) is \undefined and not /PhantomJS/.test window?navigator?userAgent
+  if typeof (-> @).call(void) is \undefined
     throws (-> String::at.call null, 0), TypeError
     throws (-> String::at.call void, 0), TypeError


### PR DESCRIPTION
PhantonJS 1.x (and old versions of webkit, Safari, etc) don't properly
handle "use strict" directives if they are nested in functions more than
two deep.  Add a top-level "use strict" inside the first nested function
scope in order to prevent this bug from affecting core-js.