### PR TITLE
Ensure that we replace Date#toISOString if native implementation is broken

### DIFF
--- a/modules/es5.js
+++ b/modules/es5.js
@@ -240,7 +240,11 @@ function lz(num){
   return num > 9 ? num : '0' + num;
 }
 // 20.3.4.36 / 15.9.5.43 Date.prototype.toISOString()
-$def($def.P, 'Date', {toISOString: function(){
+function brokenDate() {
+  // PhantomJS and old webkit had a broken Date implementation.
+  return new Date(-5e13 - 1).toISOString() !== '0385-07-25T07:06:39.999Z';
+}
+$def($def.P + $def.F * brokenDate(), 'Date', {toISOString: function(){
   if(!isFinite(this))throw RangeError('Invalid time value');
   var d = this
     , y = d.getUTCFullYear()


### PR DESCRIPTION
The Date#toISOString function in PhantonJS 1.x (and old versions of
webkit, Safari, etc) returns "-01" in the millisecond field in some
cases.  Test for this and ensure that we override the native
implementation in this case.