### PR TITLE
Check whether Object.freeze is stubbed out before using it in tests.

### DIFF
--- a/tests/tests/es6.reflect.ls
+++ b/tests/tests/es6.reflect.ls
@@ -7,6 +7,13 @@ deq = deepEqual
 isFunction = -> typeof! it is \Function
 
 MODERN = (-> try 2 == Object.defineProperty({}, \a, get: -> 2)a)!
+REAL_FREEZE = (->
+  'use strict';
+  x = Object.freeze({})
+  try
+    x.f=true
+  x.f
+)!
 
 test \Reflect !->
   ok Reflect?, 'Reflect is defined'
@@ -196,4 +203,5 @@ if '__proto__' of Object:: => test 'Reflect.setPrototypeOf' !->
   throws (-> Reflect.setPrototypeOf {}, 42), TypeError
   throws (-> Reflect.setPrototypeOf 42, {}), TypeError, 'throws on primitive'
   ok Reflect.setPrototypeOf(o = {}, o) is no, 'false on recursive __proto__'
-  ok Reflect.setPrototypeOf(Object.freeze({}), {}) is no, 'false on frozen object'
+  if REAL_FREEZE
+    ok Reflect.setPrototypeOf(Object.freeze({}), {}) is no, 'false on frozen object'


### PR DESCRIPTION
In PhantomJS (and older webkit and Safari) we stub out Object.freeze
using an identity function.  Test to see whether we have a functional
Object.freeze before using it in our test suite.