### PR TITLE
Ensure that 'npm test' rebuilds before testing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "lint": "eslint es5 es6 es7 js web core fn modules",
     "promises-tests": "promises-aplus-tests tests/promises_tests_adapter",
-    "test": "npm run lint && grunt karma:continuous && npm run promises-tests"
+    "test": "npm run lint && grunt client livescript karma:continuous && npm run promises-tests"
   },
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
This makes it much less likely you'll be surprised by testing out-of-date
sources.

I could have added a bunch of different targets ("npm run build", "npm run rebuild", "npm run quick-test", etc) but I think it's best if `npm test` just does the thing which is most correct, even if it's not the fastest way to (re)run the test suite.