### PR TITLE
Add subclass tests for Promise

### DIFF
--- a/tests/tests-library/es6.promise.ls
+++ b/tests/tests-library/es6.promise.ls
@@ -34,3 +34,32 @@ test '.resolve' !->
   ok isFunction(core.Promise.resolve), 'Is function'
 test '.reject' !->
   ok isFunction(core.Promise.reject), 'Is function'
+if core.Object.setPrototypeOf
+  test ' subclassing' !->
+    # this is ES5 syntax to create a valid ES6 subclass
+    SubPromise = (x) ->
+      self = new core.Promise(x)
+      core.Object.setPrototypeOf(self, SubPromise.prototype)
+      self.mine = 'subclass'
+      self
+    core.Object.setPrototypeOf(SubPromise, core.Promise)
+    SubPromise.prototype = core.Object.create(core.Promise.prototype)
+    SubPromise.prototype.constructor = SubPromise
+    # now let's see if this works like a proper subclass.
+    p1 = SubPromise.resolve(5)
+    strictEqual p1.mine, 'subclass'
+    p1 = p1.then( (x) -> strictEqual x, 5 )
+    strictEqual p1.mine, 'subclass'
+
+    p2 = new SubPromise( (r) -> r(6) )
+    strictEqual p2.mine, 'subclass'
+    p2 = p2.then( (x) -> strictEqual x, 6 )
+    strictEqual p2.mine, 'subclass'
+
+    p3 = SubPromise.all([p1, p2])
+    strictEqual p3.mine, 'subclass'
+    # double check
+    ok p3 instanceof core.Promise
+    ok p3 instanceof SubPromise
+    # check the async values
+    p3.then( it.async!, ((e) -> ok(false, e)) )

--- a/tests/tests/es6.promise.ls
+++ b/tests/tests/es6.promise.ls
@@ -34,3 +34,32 @@ test '.resolve' !->
   ok isFunction(Promise.resolve), 'Is function'
 test '.reject' !->
   ok isFunction(Promise.reject), 'Is function'
+if Object.setPrototypeOf
+  test ' subclassing' !->
+    # this is ES5 syntax to create a valid ES6 subclass
+    SubPromise = (x) ->
+      self = new Promise(x)
+      Object.setPrototypeOf(self, SubPromise.prototype)
+      self.mine = 'subclass'
+      self
+    Object.setPrototypeOf(SubPromise, Promise)
+    SubPromise.prototype = Object.create(Promise.prototype)
+    SubPromise.prototype.constructor = SubPromise
+    # now let's see if this works like a proper subclass.
+    p1 = SubPromise.resolve(5)
+    strictEqual p1.mine, 'subclass'
+    p1 = p1.then( (x) -> strictEqual x, 5 )
+    strictEqual p1.mine, 'subclass'
+
+    p2 = new SubPromise( (r) -> r(6) )
+    strictEqual p2.mine, 'subclass'
+    p2 = p2.then( (x) -> strictEqual x, 6 )
+    strictEqual p2.mine, 'subclass'
+
+    p3 = SubPromise.all([p1, p2])
+    strictEqual p3.mine, 'subclass'
+    # double check
+    ok p3 instanceof Promise
+    ok p3 instanceof SubPromise
+    # check the async values
+    p3.then( it.async!, ((e) -> ok(false, e)) )


### PR DESCRIPTION
Add a subclass test for the Promise implementation.

This passes on iojs, Chrome, and Firefox, using native Promises, and passes in PhantomJS and Opera using core-js's Promise implementation.  It fails in Firefox 33.0.0 using its native Promises; see https://github.com/babel/babel/issues/1320#issuecomment-95654726