### PR TITLE
Fix Math.hypot normalization issues

### DIFF
--- a/modules/es6.math.js
+++ b/modules/es6.math.js
@@ -76,9 +76,9 @@ $def($def.S, 'Math', {
     while(len1--){
       arg = args[len1] = +arguments[len1];
       if(arg == Infinity || arg == -Infinity)return Infinity;
-      if(arg > larg)larg = arg;
+      if(abs(arg) > larg)larg = abs(arg);
     }
-    larg = arg || 1;
+    larg = larg || 1;
     while(len2--)sum += pow(args[len2] / larg, 2);
     return larg * sqrt(sum);
   },

--- a/tests/tests/es6.math.ls
+++ b/tests/tests/es6.math.ls
@@ -161,6 +161,8 @@ test 'Math.hypot' !->
   eq hypot(1e+300, 1e+300), 1.4142135623730952e+300
   eq hypot(1e-300, 1e-300), 1.4142135623730952e-300
   eq hypot(1e+300, 1e+300, 2, 3), 1.4142135623730952e+300
+  eq hypot(-3, 4), 5
+  eq hypot(3, -4), 5
 test 'Math.imul' !->
   {imul} = Math
   ok isFunction(imul), 'Is function'


### PR DESCRIPTION
Math.hypot will now correctly use the largest (absolute) value for normalization. 
This also fixes a bug where hypot would return a negative result if the first argument is negative.