### PR TITLE
Do not escape `/`

### DIFF
--- a/modules/es7.regexp.escape.js
+++ b/modules/es7.regexp.escape.js
@@ -1,5 +1,5 @@
 // https://github.com/benjamingr/RexExp.escape
 var $def = require('./$.def');
 $def($def.S, 'RegExp', {
-  escape: require('./$.replacer')(/[\/\\^$*+?.()|[\]{}]/g, '\\$&', true)
+  escape: require('./$.replacer')(/[\\^$*+?.()|[\]{}]/g, '\\$&', true)
 });


### PR DESCRIPTION
Hey, updating the polyfill based on change in https://github.com/benjamingr/RexExp.escape, based on usage data escaping it isn't required (see the data folder for more motivation for this decision).