### PR TITLE
Update `Promise.reject` behavior.

### DIFF
--- a/modules/es6.promise.js
+++ b/modules/es6.promise.js
@@ -219,7 +219,7 @@ species(Wrapper = $.core[PROMISE]);
 $def($def.S + $def.F * !useNative, PROMISE, {
   // 25.4.4.5 Promise.reject(r)
   reject: function reject(r){
-    return new (getConstructor(this))(function(res, rej){ rej(r); });
+    return new this(function(res, rej){ rej(r); });
   }
 });
 $def($def.S + $def.F * (!useNative || testResolve(true)), PROMISE, {


### PR DESCRIPTION
This was a last-minute change to the ECMA-262 spec, now finalized at:
http://www.ecma-international.org/ecma-262/6.0/#sec-promise.reject