### PR TITLE
Pubish individual modules to NPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ node_modules/
 *.log
 *.bak
 *.swp
-
+client/modules
 Thumbs.db
 
 Desktop.ini

--- a/build/Gruntfile.ls
+++ b/build/Gruntfile.ls
@@ -61,7 +61,8 @@ module.exports = (grunt)->
   grunt.registerTask \build-module, (moduleName) ->
     version = moduleName.slice(0,3)
     grunt.option \path, "./client/modules/#{version}/#{moduleName}-umd"
-    grunt.task.run ["build:#{moduleName}"]
+    grunt.option \library, true
+    grunt.task.run ["build:#{moduleName}", "uglify"]
   grunt.registerTask \build (options)->
     done = @async!
     err, it <- build {

--- a/build/Gruntfile.ls
+++ b/build/Gruntfile.ls
@@ -1,4 +1,4 @@
-require! <[./build fs ./config]>
+require! <[./build fs ./config path]>
 module.exports = (grunt)->
   grunt.loadNpmTasks \grunt-contrib-clean
   grunt.loadNpmTasks \grunt-contrib-copy
@@ -44,6 +44,24 @@ module.exports = (grunt)->
         configFile: './tests/karma.conf.js'
         singleRun: true
         browsers: ['PhantomJS']
+  grunt.registerTask \modularize ->
+    versions = <[es6 es7]>
+    versions.forEach((v) -> grunt.file.mkdir(path.resolve(\client, \modules, v)))
+
+    fs.readdirSync(path.resolve(\modules))
+    .filter((filename) -> fs.statSync(path.resolve(\modules, filename)).isFile())
+    .filter((filename) ->
+      versionOfFile = filename.slice 0 3
+      versionOfFile in versions
+    )
+    .map((filename) -> filename.slice(0, -3))
+    .map((moduleName) ->
+      grunt.task.run [\build-module: + moduleName]
+    )
+  grunt.registerTask \build-module, (moduleName) ->
+    version = moduleName.slice(0,3)
+    grunt.option \path, "./client/modules/#{version}/#{moduleName}-umd"
+    grunt.task.run ["build:#{moduleName}"]
   grunt.registerTask \build (options)->
     done = @async!
     err, it <- build {

--- a/build/Gruntfile.ls
+++ b/build/Gruntfile.ls
@@ -94,7 +94,6 @@ module.exports = (grunt)->
   grunt.registerTask \build-module, (moduleName) ->
     version = moduleName.slice(0,3)
     grunt.option \path, "./client/modules/#{version}/#{moduleName}/#{moduleName}-umd"
-    grunt.option \library, true
     grunt.task.run ["build:#{moduleName}", "uglify"]
     grunt.task.run ["createPackage:#{moduleName}"]
   grunt.registerTask \build (options)->


### PR DESCRIPTION
Being able to require in individual polyfills from NPM would be a great way for user's to consume parts of this library. When it comes to code that is going to live in a browser, having each module imported individually should help decrease the overall bundled size when using browserify/webpack.