### PR TITLE
Make Array.from more Minifier friendly.

### DIFF
--- a/modules/es6.array.from.js
+++ b/modules/es6.array.from.js
@@ -23,7 +23,8 @@ $def($def.S + $def.F * !require('./$.iter-detect')(function(iter){ Array.from(it
         result[index] = mapping ? call(iterator, mapfn, [step.value, index], true) : step.value;
       }
     } else {
-      for(result = new C(length = toLength(O.length)); length > index; index++){
+      length = toLength(O.length);
+      for(result = new C(length); length > index; index++){
         result[index] = mapping ? mapfn(O[index], index) : O[index];
       }
     }


### PR DESCRIPTION
Certain minifiers will reuse references, which breaks in Safari8 and IE<10

Addresses Issue  #111