### PR TITLE
Better Promise unhandled rejection logging

### DIFF
--- a/modules/es6.promise.js
+++ b/modules/es6.promise.js
@@ -135,7 +135,7 @@ var onUnhandled = function(promise){
       } else if(handler = global.onunhandledrejection){
         handler({promise: promise, reason: value});
       } else if((console = global.console) && console.error){
-        console.error('Unhandled promise rejection', value);
+        console.error('Unhandled promise rejection', isObject(value) && value.stack || value);
       } promise._h = 2;
     } promise._a = undefined;
   });


### PR DESCRIPTION
The current logging of unhandled Promise rejections in the browser is not very helpful, as it does not print a stack trace with line numbers.

This PR prints a stack trace when available, which in most browsers results in clickable line numbers being displayed, linking back to the original error source. This provides a better developer experience when tracking down the root cause of unhandled promise rejections.
