### PR TITLE
Allow user to specify that built output should not export core

### DIFF
--- a/build/build.ls
+++ b/build/build.ls
@@ -6,7 +6,7 @@ require! {
   webpack, temp
 }
 
-module.exports = ({modules = [], blacklist = [], library = no})->
+module.exports = ({modules = [], blacklist = [], library = no, exportCore = on})->
   resolve, reject <~! new Promise _
   let @ = modules.reduce ((memo, it)-> memo[it] = on; memo), {}
     if @exp => for experimental => @[..] = on
@@ -40,16 +40,23 @@ module.exports = ({modules = [], blacklist = [], library = no})->
     err <~! unlink TARGET
     if err => return reject err
 
+    if exportCore
+      exportScript = """
+        // CommonJS export
+        if(typeof module != 'undefined' && module.exports)module.exports = __e;
+        // RequireJS export
+        else if(typeof define == 'function' && define.amd)define(function(){return __e});
+        // Export to global object
+        else __g.core = __e;
+        """
+    else
+      exportScript = ""
+
     resolve """
       #banner
       !function(__e, __g, undefined){
       'use strict';
       #script
-      // CommonJS export
-      if(typeof module != 'undefined' && module.exports)module.exports = __e;
-      // RequireJS export
-      else if(typeof define == 'function' && define.amd)define(function(){return __e});
-      // Export to global object
-      else __g.core = __e;
+      #exportScript
       }(1, 1);
       """

--- a/build/index.js
+++ b/build/index.js
@@ -8,12 +8,12 @@
   webpack = require('webpack');
   temp = require('temp');
   module.exports = function(arg$){
-    var modules, ref$, blacklist, library, this$ = this;
+    var modules, ref$, blacklist, library, exportCore, this$ = this;
     modules = (ref$ = arg$.modules) != null
       ? ref$
       : [], blacklist = (ref$ = arg$.blacklist) != null
       ? ref$
-      : [], library = (ref$ = arg$.library) != null ? ref$ : false;
+      : [], library = (ref$ = arg$.library) != null ? ref$ : false, exportCore = (ref$ = arg$.exportCore) != null ? ref$ : true;
     return new Promise(function(resolve, reject){
       (function(){
         var i$, x$, ref$, len$, y$, ns, name, j$, len1$, TARGET, this$ = this;
@@ -77,10 +77,16 @@
               return reject(err);
             }
             unlink(TARGET, function(err){
+              var exportScript;
               if (err) {
                 return reject(err);
               }
-              resolve("" + banner + "\n!function(__e, __g, undefined){\n'use strict';\n" + script + "\n// CommonJS export\nif(typeof module != 'undefined' && module.exports)module.exports = __e;\n// RequireJS export\nelse if(typeof define == 'function' && define.amd)define(function(){return __e});\n// Export to global object\nelse __g.core = __e;\n}(1, 1);");
+              if (exportCore) {
+                exportScript = "// CommonJS export\nif(typeof module != 'undefined' && module.exports)module.exports = __e;\n// RequireJS export\nelse if(typeof define == 'function' && define.amd)define(function(){return __e});\n// Export to global object\nelse __g.core = __e;";
+              } else {
+                exportScript = "";
+              }
+              resolve("" + banner + "\n!function(__e, __g, undefined){\n'use strict';\n" + script + "\n" + exportScript + "\n}(1, 1);");
             });
           });
         });


### PR DESCRIPTION
Adds an `exportCore` option to core-js-builder that defaults to true.
If set to false, the compiled output will not contain a UMD wrapper to export the core library.

In one of our projects, we're using core-js to polyfill native Promises, but the UMD wrapper here causes problems with our test runner (because we're using r.js in our test runner, and it doesn't support the anonymous define module format).

Because we're only relying on core-js to polyfill functionality into the global scope, the exported package is unneeded- so this option would allow us to not export anything.