### PR TITLE
Port Yaku to core-js

### DIFF
--- a/modules/es6.promise.js
+++ b/modules/es6.promise.js
@@ -1,26 +1,12 @@
 'use strict';
-var LIBRARY            = require('./_library')
-  , global             = require('./_global')
-  , ctx                = require('./_ctx')
-  , classof            = require('./_classof')
+var global             = require('./_global')
   , $export            = require('./_export')
-  , isObject           = require('./_is-object')
-  , anObject           = require('./_an-object')
-  , aFunction          = require('./_a-function')
-  , anInstance         = require('./_an-instance')
-  , forOf              = require('./_for-of')
-  , setProto           = require('./_set-proto').set
-  , speciesConstructor = require('./_species-constructor')
-  , task               = require('./_task').set
-  , microtask          = require('./_microtask')
+  , redefine           = require('./_redefine')
+  , wks                = require('./_wks')
   , PROMISE            = 'Promise'
-  , TypeError          = global.TypeError
-  , process            = global.process
   , $Promise           = global[PROMISE]
-  , process            = global.process
-  , isNode             = classof(process) == 'process'
   , empty              = function(){ /* empty */ }
-  , Internal, GenericPromiseCapability, Wrapper;
+  , Yaku               = require('./yaku');
 
 var USE_NATIVE = !!function(){
   try {
@@ -32,270 +18,36 @@ var USE_NATIVE = !!function(){
   } catch(e){ /* empty */ }
 }();
 
-// helpers
-var sameConstructor = function(a, b){
-  // with library wrapper special case
-  return a === b || a === $Promise && b === Wrapper;
-};
-var isThenable = function(it){
-  var then;
-  return isObject(it) && typeof (then = it.then) == 'function' ? then : false;
-};
-var newPromiseCapability = function(C){
-  return sameConstructor($Promise, C)
-    ? new PromiseCapability(C)
-    : new GenericPromiseCapability(C);
-};
-var PromiseCapability = GenericPromiseCapability = function(C){
-  var resolve, reject;
-  this.promise = new C(function($$resolve, $$reject){
-    if(resolve !== undefined || reject !== undefined)throw TypeError('Bad Promise constructor');
-    resolve = $$resolve;
-    reject  = $$reject;
-  });
-  this.resolve = aFunction(resolve);
-  this.reject  = aFunction(reject);
-};
-var perform = function(exec){
-  try {
-    exec();
-  } catch(e){
-    return {error: e};
-  }
-};
-var notify = function(promise, isReject){
-  if(promise._n)return;
-  promise._n = true;
-  var chain = promise._c;
-  microtask(function(){
-    var value = promise._v
-      , ok    = promise._s == 1
-      , i     = 0;
-    var run = function(reaction){
-      var handler = ok ? reaction.ok : reaction.fail
-        , resolve = reaction.resolve
-        , reject  = reaction.reject
-        , domain  = reaction.domain
-        , result, then;
-      try {
-        if(handler){
-          if(!ok){
-            if(promise._h == 2)onHandleUnhandled(promise);
-            promise._h = 1;
-          }
-          if(handler === true)result = value;
-          else {
-            if(domain)domain.enter();
-            result = handler(value);
-            if(domain)domain.exit();
-          }
-          if(result === reaction.promise){
-            reject(TypeError('Promise-chain cycle'));
-          } else if(then = isThenable(result)){
-            then.call(result, resolve, reject);
-          } else resolve(result);
-        } else reject(value);
-      } catch(e){
-        reject(e);
-      }
-    };
-    while(chain.length > i)run(chain[i++]); // variable length - can't use forEach
-    promise._c = [];
-    promise._n = false;
-    if(isReject && !promise._h)onUnhandled(promise);
-  });
-};
-var onUnhandled = function(promise){
-  task.call(global, function(){
-    var value = promise._v
-      , abrupt, handler, console;
-    if(isUnhandled(promise)){
-      abrupt = perform(function(){
-        if(isNode){
-          process.emit('unhandledRejection', value, promise);
-        } else if(handler = global.onunhandledrejection){
-          handler({promise: promise, reason: value});
-        } else if((console = global.console) && console.error){
-          console.error('Unhandled promise rejection', value);
-        }
-      });
-      // Browsers should not trigger `rejectionHandled` event if it was handled here, NodeJS - should
-      promise._h = isNode || isUnhandled(promise) ? 2 : 1;
-    } promise._a = undefined;
-    if(abrupt)throw abrupt.error;
-  });
-};
-var isUnhandled = function(promise){
-  if(promise._h == 1)return false;
-  var chain = promise._a || promise._c
-    , i     = 0
-    , reaction;
-  while(chain.length > i){
-    reaction = chain[i++];
-    if(reaction.fail || !isUnhandled(reaction.promise))return false;
-  } return true;
-};
-var onHandleUnhandled = function(promise){
-  task.call(global, function(){
-    var handler;
-    if(isNode){
-      process.emit('rejectionHandled', promise);
-    } else if(handler = global.onrejectionhandled){
-      handler({promise: promise, reason: promise._v});
-    }
-  });
-};
-var $reject = function(value){
-  var promise = this;
-  if(promise._d)return;
-  promise._d = true;
-  promise = promise._w || promise; // unwrap
-  promise._v = value;
-  promise._s = 2;
-  if(!promise._a)promise._a = promise._c.slice();
-  notify(promise, true);
-};
-var $resolve = function(value){
-  var promise = this
-    , then;
-  if(promise._d)return;
-  promise._d = true;
-  promise = promise._w || promise; // unwrap
-  try {
-    if(promise === value)throw TypeError("Promise can't be resolved itself");
-    if(then = isThenable(value)){
-      microtask(function(){
-        var wrapper = {_w: promise, _d: false}; // wrap
-        try {
-          then.call(value, ctx($resolve, wrapper, 1), ctx($reject, wrapper, 1));
-        } catch(e){
-          $reject.call(wrapper, e);
-        }
-      });
-    } else {
-      promise._v = value;
-      promise._s = 1;
-      notify(promise, false);
-    }
-  } catch(e){
-    $reject.call({_w: promise, _d: false}, e); // wrap
-  }
-};
-
 // constructor polyfill
 if(!USE_NATIVE){
-  // 25.4.3.1 Promise(executor)
-  $Promise = function Promise(executor){
-    anInstance(this, $Promise, PROMISE, '_h');
-    aFunction(executor);
-    Internal.call(this);
-    try {
-      executor(ctx($resolve, this, 1), ctx($reject, this, 1));
-    } catch(err){
-      $reject.call(this, err);
+
+  // Promise need two well-known symbols.
+  Yaku.Symbol = {
+    iterator: wks('iterator'),
+    species: wks('species'),
+  };
+
+  // Use the special optimized microtask.
+  Yaku.nextTick = require('./_microtask');
+
+  // For subclass construction.
+  Yaku.speciesConstructor = require('./_species-constructor');
+
+  $Promise = Yaku;
+
+  var redefineAll = function (target) {
+    var k;
+    for (k in target) {
+      var v = target[k];
+      delete target[k];
+      redefine(target, k, v);
     }
-  };
-  Internal = function Promise(executor){
-    this._c = [];             // <- awaiting reactions
-    this._a = undefined;      // <- checked in isUnhandled reactions
-    this._s = 0;              // <- state
-    this._d = false;          // <- done
-    this._v = undefined;      // <- value
-    this._h = 0;              // <- rejection state, 0 - default, 1 - handled, 2 - unhandled
-    this._n = false;          // <- notify
-  };
-  Internal.prototype = require('./_redefine-all')($Promise.prototype, {
-    // 25.4.5.3 Promise.prototype.then(onFulfilled, onRejected)
-    then: function then(onFulfilled, onRejected){
-      var reaction    = newPromiseCapability(speciesConstructor(this, $Promise));
-      reaction.ok     = typeof onFulfilled == 'function' ? onFulfilled : true;
-      reaction.fail   = typeof onRejected == 'function' && onRejected;
-      reaction.domain = isNode ? process.domain : undefined;
-      this._c.push(reaction);
-      if(this._a)this._a.push(reaction);
-      if(this._s)notify(this, false);
-      return reaction.promise;
-    },
-    // 25.4.5.1 Promise.prototype.catch(onRejected)
-    'catch': function(onRejected){
-      return this.then(undefined, onRejected);
-    }
-  });
-  PromiseCapability = function(){
-    var promise  = new Internal;
-    this.promise = promise;
-    this.resolve = ctx($resolve, promise, 1);
-    this.reject  = ctx($reject, promise, 1);
-  };
+  }
+
+  redefineAll($Promise);
+  redefineAll($Promise.prototype);
 }
 
 $export($export.G + $export.W + $export.F * !USE_NATIVE, {Promise: $Promise});
 require('./_set-to-string-tag')($Promise, PROMISE);
 require('./_set-species')(PROMISE);
-Wrapper = require('./_core')[PROMISE];
-
-// statics
-$export($export.S + $export.F * !USE_NATIVE, PROMISE, {
-  // 25.4.4.5 Promise.reject(r)
-  reject: function reject(r){
-    var capability = newPromiseCapability(this)
-      , $$reject   = capability.reject;
-    $$reject(r);
-    return capability.promise;
-  }
-});
-$export($export.S + $export.F * (LIBRARY || !USE_NATIVE), PROMISE, {
-  // 25.4.4.6 Promise.resolve(x)
-  resolve: function resolve(x){
-    // instanceof instead of internal slot check because we should fix it without replacement native Promise core
-    if(x instanceof $Promise && sameConstructor(x.constructor, this))return x;
-    var capability = newPromiseCapability(this)
-      , $$resolve  = capability.resolve;
-    $$resolve(x);
-    return capability.promise;
-  }
-});
-$export($export.S + $export.F * !(USE_NATIVE && require('./_iter-detect')(function(iter){
-  $Promise.all(iter)['catch'](empty);
-})), PROMISE, {
-  // 25.4.4.1 Promise.all(iterable)
-  all: function all(iterable){
-    var C          = this
-      , capability = newPromiseCapability(C)
-      , resolve    = capability.resolve
-      , reject     = capability.reject;
-    var abrupt = perform(function(){
-      var values    = []
-        , index     = 0
-        , remaining = 1;
-      forOf(iterable, false, function(promise){
-        var $index        = index++
-          , alreadyCalled = false;
-        values.push(undefined);
-        remaining++;
-        C.resolve(promise).then(function(value){
-          if(alreadyCalled)return;
-          alreadyCalled  = true;
-          values[$index] = value;
-          --remaining || resolve(values);
-        }, reject);
-      });
-      --remaining || resolve(values);
-    });
-    if(abrupt)reject(abrupt.error);
-    return capability.promise;
-  },
-  // 25.4.4.4 Promise.race(iterable)
-  race: function race(iterable){
-    var C          = this
-      , capability = newPromiseCapability(C)
-      , reject     = capability.reject;
-    var abrupt = perform(function(){
-      forOf(iterable, false, function(promise){
-        C.resolve(promise).then(capability.resolve, reject);
-      });
-    });
-    if(abrupt)reject(abrupt.error);
-    return capability.promise;
-  }
-});

--- a/modules/yaku.js
+++ b/modules/yaku.js
@@ -1,0 +1,826 @@
+/*eslint-disable*/
+(function () {
+    "use strict";
+
+    var $undefined
+    , $null = null
+    , root = typeof global === "object" ? global : window
+    , isLongStackTrace = false
+    , process = root.process
+    , Arr = Array
+    , Err = Error
+
+    , $rejected = 0
+    , $resolved = 1
+    , $pending = 2
+
+    , $Symbol = "Symbol"
+    , $iterator = "iterator"
+    , $return = "return"
+
+    , $unhandled = "_uh"
+    , $promiseTrace = "_pt"
+    , $settlerTrace = "_st"
+
+    , $invalidThis = "Invalid this"
+    , $invalidArgument = "Invalid argument"
+    , $fromPrevious = "\nFrom previous "
+    , $promiseCircularChain = "Chaining cycle detected for promise"
+    , $unhandledRejectionMsg = "Uncaught (in promise)"
+    , $rejectionHandled = "rejectionHandled"
+    , $unhandledRejection = "unhandledRejection"
+
+    , $tryCatchFn
+    , $tryCatchThis
+    , $tryErr = { e: $null }
+    , $noop = function () {}
+    ;
+
+    /**
+     * This class follows the [Promises/A+](https://promisesaplus.com) and
+     * [ES6](http://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects) spec
+     * with some extra helpers.
+     * @param  {Function} executor Function object with two arguments resolve, reject.
+     * The first argument fulfills the promise, the second argument rejects it.
+     * We can call these functions, once our operation is completed.
+     */
+    var Yaku = module.exports = function Promise (executor) {
+        var self = this,
+            err;
+
+        // "this._s" is the internal state of: pending, resolved or rejected
+        // "this._v" is the internal value
+
+        if (!isObject(self) || self._s !== $undefined)
+            throw genTypeError($invalidThis);
+
+        self._s = $pending;
+
+        if (isLongStackTrace) self[$promiseTrace] = genTraceInfo();
+
+        if (executor !== $noop) {
+            if (!isFunction(executor))
+                throw genTypeError($invalidArgument);
+
+            err = genTryCatcher(executor)(
+                genSettler(self, $resolved),
+                genSettler(self, $rejected)
+            );
+
+            if (err === $tryErr)
+                settlePromise(self, $rejected, err.e);
+        }
+    };
+
+    Yaku["default"] = Yaku;
+
+    extendPrototype(Yaku, {
+        /**
+         * Appends fulfillment and rejection handlers to the promise,
+         * and returns a new promise resolving to the return value of the called handler.
+         * @param  {Function} onFulfilled Optional. Called when the Promise is resolved.
+         * @param  {Function} onRejected  Optional. Called when the Promise is rejected.
+         * @return {Yaku} It will return a new Yaku which will resolve or reject after
+         * @example
+         * the current Promise.
+         * ```js
+         * var Promise = require('yaku');
+         * var p = Promise.resolve(10);
+         *
+         * p.then((v) => {
+         *     console.log(v);
+         * });
+         * ```
+         */
+        then: function then (onFulfilled, onRejected) {
+            return addHandler(
+                this,
+                newCapablePromise(Yaku.speciesConstructor(this, Yaku)),
+                onFulfilled,
+                onRejected
+            );
+        },
+
+        /**
+         * The `catch()` method returns a Promise and deals with rejected cases only.
+         * It behaves the same as calling `Promise.prototype.then(undefined, onRejected)`.
+         * @param  {Function} onRejected A Function called when the Promise is rejected.
+         * This function has one argument, the rejection reason.
+         * @return {Yaku} A Promise that deals with rejected cases only.
+         * @example
+         * ```js
+         * var Promise = require('yaku');
+         * var p = Promise.reject(new Error("ERR"));
+         *
+         * p['catch']((v) => {
+         *     console.log(v);
+         * });
+         * ```
+         */
+        "catch": function (onRejected) {
+            return this.then($undefined, onRejected);
+        },
+
+        // The number of current promises that attach to this Yaku instance.
+        _pCount: 0,
+
+        // The parent Yaku.
+        _pre: $null,
+
+        // A unique type flag, it helps different versions of Yaku know each other.
+        _Yaku: 1
+    });
+
+    /**
+     * The `Promise.resolve(value)` method returns a Promise object that is resolved with the given value.
+     * If the value is a thenable (i.e. has a then method), the returned promise will "follow" that thenable,
+     * adopting its eventual state; otherwise the returned promise will be fulfilled with the value.
+     * @param  {Any} value Argument to be resolved by this Promise.
+     * Can also be a Promise or a thenable to resolve.
+     * @return {Yaku}
+     * @example
+     * ```js
+     * var Promise = require('yaku');
+     * var p = Promise.resolve(10);
+     * ```
+     */
+    Yaku.resolve = function resolve (val) {
+        return isYaku(val) ? val : settleWithX(newCapablePromise(this), val);
+    };
+
+    /**
+     * The `Promise.reject(reason)` method returns a Promise object that is rejected with the given reason.
+     * @param  {Any} reason Reason why this Promise rejected.
+     * @return {Yaku}
+     * @example
+     * ```js
+     * var Promise = require('yaku');
+     * var p = Promise.reject(new Error("ERR"));
+     * ```
+     */
+    Yaku.reject = function reject (reason) {
+        return settlePromise(newCapablePromise(this), $rejected, reason);
+    };
+
+    /**
+     * The `Promise.race(iterable)` method returns a promise that resolves or rejects
+     * as soon as one of the promises in the iterable resolves or rejects,
+     * with the value or reason from that promise.
+     * @param  {iterable} iterable An iterable object, such as an Array.
+     * @return {Yaku} The race function returns a Promise that is settled
+     * the same way as the first passed promise to settle.
+     * It resolves or rejects, whichever happens first.
+     * @example
+     * ```js
+     * var Promise = require('yaku');
+     * Promise.race([
+     *     123,
+     *     Promise.resolve(0)
+     * ])
+     * .then((value) => {
+     *     console.log(value); // => 123
+     * });
+     * ```
+     */
+    Yaku.race = function race (iterable) {
+        var self = this
+        , p = newCapablePromise(self)
+
+        , resolve = function (val) {
+            settlePromise(p, $resolved, val);
+        }
+
+        , reject = function (val) {
+            settlePromise(p, $rejected, val);
+        }
+
+        , ret = genTryCatcher(each)(iterable, function (v) {
+            self.resolve(v).then(resolve, reject);
+        });
+
+        if (ret === $tryErr) return self.reject(ret.e);
+
+        return p;
+    };
+
+    /**
+     * The `Promise.all(iterable)` method returns a promise that resolves when
+     * all of the promises in the iterable argument have resolved.
+     *
+     * The result is passed as an array of values from all the promises.
+     * If something passed in the iterable array is not a promise,
+     * it's converted to one by Promise.resolve. If any of the passed in promises rejects,
+     * the all Promise immediately rejects with the value of the promise that rejected,
+     * discarding all the other promises whether or not they have resolved.
+     * @param  {iterable} iterable An iterable object, such as an Array.
+     * @return {Yaku}
+     * @example
+     * ```js
+     * var Promise = require('yaku');
+     * Promise.all([
+     *     123,
+     *     Promise.resolve(0)
+     * ])
+     * .then((values) => {
+     *     console.log(values); // => [123, 0]
+     * });
+     * ```
+     * @example
+     * Use with iterable.
+     * ```js
+     * var Promise = require('yaku');
+     * Promise.all((function * () {
+     *     yield 10;
+     *     yield new Promise(function (r) { setTimeout(r, 1000, "OK") });
+     * })())
+     * .then((values) => {
+     *     console.log(values); // => [123, 0]
+     * });
+     * ```
+     */
+    Yaku.all = function all (iterable) {
+        var self = this
+        , p1 = newCapablePromise(self)
+        , res = []
+        , ret
+        ;
+
+        function reject (reason) {
+            settlePromise(p1, $rejected, reason);
+        }
+
+        ret = genTryCatcher(each)(iterable, function (item, i) {
+            self.resolve(item).then(function (value) {
+                res[i] = value;
+                if (!--ret) settlePromise(p1, $resolved, res);
+            }, reject);
+        });
+
+        if (ret === $tryErr) return self.reject(ret.e);
+
+        if (!ret) settlePromise(p1, $resolved, []);
+
+        return p1;
+    };
+
+    /**
+     * The ES6 Symbol object that Yaku should use, by default it will use the
+     * global one.
+     * @type {Object}
+     * @example
+     * ```js
+     * var core = require("core-js/library");
+     * var Promise = require("yaku");
+     * Promise.Symbol = core.Symbol;
+     * ```
+     */
+    Yaku.Symbol = root[$Symbol] || {};
+
+    /**
+     * Use this api to custom the species behavior.
+     * https://tc39.github.io/ecma262/#sec-speciesconstructor
+     * @param {Any} O The current this object.
+     * @param {Function} defaultConstructor
+     */
+    Yaku.speciesConstructor = function (O, D) {
+        var C = O.constructor;
+
+        return C ? (C[Yaku[$Symbol].species] || C) : D;
+    };
+
+    /**
+     * Catch all possibly unhandled rejections. If you want to use specific
+     * format to display the error stack, overwrite it.
+     * If it is set, auto `console.error` unhandled rejection will be disabled.
+     * @param {Any} reason The rejection reason.
+     * @param {Yaku} p The promise that was rejected.
+     * @example
+     * ```js
+     * var Promise = require('yaku');
+     * Promise.onUnhandledRejection = (reason) => {
+     *     console.error(reason);
+     * };
+     *
+     * // The console will log an unhandled rejection error message.
+     * Promise.reject('my reason');
+     *
+     * // The below won't log the unhandled rejection error message.
+     * Promise.reject('v').catch(() => {});
+     * ```
+     */
+    Yaku.unhandledRejection = function (reason, p) {
+        var con = root.console;
+        if (con) {
+            con.error($unhandledRejectionMsg, genStackInfo(reason, p));
+        }
+    };
+
+    /**
+     * Emitted whenever a Promise was rejected and an error handler was
+     * attached to it (for example with .catch()) later than after an event loop turn.
+     * @param {Any} reason The rejection reason.
+     * @param {Yaku} p The promise that was rejected.
+     */
+    Yaku.rejectionHandled = $noop;
+
+    /**
+     * It is used to enable the long stack trace.
+     * Once it is enabled, it can't be reverted.
+     * While it is very helpful in development and testing environments,
+     * it is not recommended to use it in production. It will slow down your
+     * application and waste your memory.
+     * @example
+     * ```js
+     * var Promise = require('yaku');
+     * Promise.enableLongStackTrace();
+     * ```
+     */
+    Yaku.enableLongStackTrace = function () {
+        isLongStackTrace = true;
+    };
+
+    /**
+     * Only Node has `process.nextTick` function. For browser there are
+     * so many ways to polyfill it. Yaku won't do it for you, instead you
+     * can choose what you prefer. For example, this project
+     * [setImmediate](https://github.com/YuzuJS/setImmediate).
+     * By default, Yaku will use `process.nextTick` on Node, `setTimeout` on browser.
+     * @type {Function}
+     * @example
+     * ```js
+     * var Promise = require('yaku');
+     * Promise.nextTick = fn => window.setImmediate(fn);
+     * ```
+     * @example
+     * You can even use sync resolution if you really know what you are doing.
+     * ```js
+     * var Promise = require('yaku');
+     * Promise.nextTick = fn => fn();
+     * ```
+     */
+    Yaku.nextTick = process ?
+        process.nextTick :
+        function (fn) { setTimeout(fn); };
+
+    // ********************** Private **********************
+
+    Yaku._Yaku = 1;
+
+    /**
+     * All static variable name will begin with `$`. Such as `$rejected`.
+     * @private
+     */
+
+    // ******************************* Utils ********************************
+
+    function extendPrototype (src, target) {
+        for (var k in target) {
+            src.prototype[k] = target[k];
+        }
+        return src;
+    }
+
+    function isObject (obj) {
+        return typeof obj === "object";
+    }
+
+    function isFunction (obj) {
+        return typeof obj === "function";
+    }
+
+    function isInstanceOf (a, b) {
+        return a instanceof b;
+    }
+
+    function isError (obj) {
+        return isInstanceOf(obj, Err);
+    }
+
+    function ensureType (obj, fn, msg) {
+        if (!fn(obj)) throw genTypeError(msg);
+    }
+
+    /**
+     * Wrap a function into a try-catch.
+     * @private
+     * @return {Any | $tryErr}
+     */
+    function tryCatcher () {
+        try {
+            return $tryCatchFn.apply($tryCatchThis, arguments);
+        } catch (e) {
+            $tryErr.e = e;
+            return $tryErr;
+        }
+    }
+
+    /**
+     * Generate a try-catch wrapped function.
+     * @private
+     * @param  {Function} fn
+     * @return {Function}
+     */
+    function genTryCatcher (fn, self) {
+        $tryCatchFn = fn;
+        $tryCatchThis = self;
+        return tryCatcher;
+    }
+
+    /**
+     * Generate a scheduler.
+     * @private
+     * @param  {Integer}  initQueueSize
+     * @param  {Function} fn `(Yaku, Value) ->` The schedule handler.
+     * @return {Function} `(Yaku, Value) ->` The scheduler.
+     */
+    function genScheduler (initQueueSize, fn) {
+        /**
+         * All async promise will be scheduled in
+         * here, so that they can be execute on the next tick.
+         * @private
+         */
+        var fnQueue = Arr(initQueueSize)
+        , fnQueueLen = 0;
+
+        /**
+         * Run all queued functions.
+         * @private
+         */
+        function flush () {
+            var i = 0;
+            while (i < fnQueueLen) {
+                fn(fnQueue[i], fnQueue[i + 1]);
+                fnQueue[i++] = $undefined;
+                fnQueue[i++] = $undefined;
+            }
+
+            fnQueueLen = 0;
+            if (fnQueue.length > initQueueSize) fnQueue.length = initQueueSize;
+        }
+
+        return function (v, arg) {
+            fnQueue[fnQueueLen++] = v;
+            fnQueue[fnQueueLen++] = arg;
+
+            if (fnQueueLen === 2) Yaku.nextTick(flush);
+        };
+    }
+
+    /**
+     * Generate a iterator
+     * @param  {Any} obj
+     * @private
+     * @return {Object || TypeError}
+     */
+    function each (iterable, fn) {
+        var len
+        , i = 0
+        , iter
+        , item
+        , ret
+        ;
+
+        if (!iterable) throw genTypeError($invalidArgument);
+
+        var gen = iterable[Yaku[$Symbol][$iterator]];
+        if (isFunction(gen))
+            iter = gen.call(iterable);
+        else if (isFunction(iterable.next))
+            iter = iterable;
+        else if (isInstanceOf(iterable, Arr)) {
+            len = iterable.length;
+            while (i < len) {
+                fn(iterable[i], i++);
+            }
+            return i;
+        } else
+            throw genTypeError($invalidArgument);
+
+        while (!(item = iter.next()).done) {
+            ret = genTryCatcher(fn)(item.value, i++);
+            if (ret === $tryErr) {
+                if (isFunction(iter[$return])) iter[$return]();
+                throw ret.e;
+            }
+        }
+
+        return i;
+    }
+
+    /**
+     * Generate type error object.
+     * @private
+     * @param  {String} msg
+     * @return {TypeError}
+     */
+    function genTypeError (msg) {
+        return new TypeError(msg);
+    }
+
+    function genTraceInfo (noTitle) {
+        return (noTitle ? "" : $fromPrevious) + (new Err().stack || "");
+    }
+
+
+    // *************************** Promise Helpers ****************************
+
+    /**
+     * Resolve the value returned by onFulfilled or onRejected.
+     * @private
+     * @param {Yaku} p1
+     * @param {Yaku} p2
+     */
+    var scheduleHandler = genScheduler(999, function (p1, p2) {
+        var x, handler;
+
+        // 2.2.2
+        // 2.2.3
+        handler = p1._s ? p2._onFulfilled : p2._onRejected;
+
+        // 2.2.7.3
+        // 2.2.7.4
+        if (handler === $undefined) {
+            settlePromise(p2, p1._s, p1._v);
+            return;
+        }
+
+        // 2.2.7.1
+        x = genTryCatcher(callHanler)(handler, p1._v);
+        if (x === $tryErr) {
+            // 2.2.7.2
+            settlePromise(p2, $rejected, x.e);
+            return;
+        }
+
+        settleWithX(p2, x);
+    });
+
+    var scheduleUnhandledRejection = genScheduler(9, function (p) {
+        if (!hashOnRejected(p)) {
+            p[$unhandled] = 1;
+            emitEvent($unhandledRejection, p);
+        }
+    });
+
+    function emitEvent (name, p) {
+        var browserEventName = "on" + name.toLowerCase()
+            , browserHandler = root[browserEventName];
+
+        if (process && process.listeners(name).length)
+            name === $unhandledRejection ?
+                process.emit(name, p._v, p) : process.emit(name, p);
+        else if (browserHandler)
+            browserHandler({ reason: p._v, promise: p });
+        else
+            Yaku[name](p._v, p);
+    }
+
+    function isYaku (val) { return val && val._Yaku; }
+
+    function newCapablePromise (Constructor) {
+        if (isYaku(Constructor)) return new Constructor($noop);
+
+        var p, r, j;
+        p = new Constructor(function (resolve, reject) {
+            if (p) throw genTypeError();
+
+            r = resolve;
+            j = reject;
+        });
+
+        ensureType(r, isFunction);
+        ensureType(j, isFunction);
+
+        return p;
+    }
+
+    /**
+     * It will produce a settlePromise function to user.
+     * Such as the resolve and reject in this `new Yaku (resolve, reject) ->`.
+     * @private
+     * @param  {Yaku} self
+     * @param  {Integer} state The value is one of `$pending`, `$resolved` or `$rejected`.
+     * @return {Function} `(value) -> undefined` A resolve or reject function.
+     */
+    function genSettler (self, state) {
+        return function (value) {
+            if (isLongStackTrace)
+                self[$settlerTrace] = genTraceInfo(true);
+
+            if (state === $resolved)
+                settleWithX(self, value);
+            else
+                settlePromise(self, state, value);
+        };
+    }
+
+    /**
+     * Link the promise1 to the promise2.
+     * @private
+     * @param {Yaku} p1
+     * @param {Yaku} p2
+     * @param {Function} onFulfilled
+     * @param {Function} onRejected
+     */
+    function addHandler (p1, p2, onFulfilled, onRejected) {
+        // 2.2.1
+        if (isFunction(onFulfilled))
+            p2._onFulfilled = onFulfilled;
+        if (isFunction(onRejected)) {
+            if (p1[$unhandled]) emitEvent($rejectionHandled, p1);
+
+            p2._onRejected = onRejected;
+        }
+
+        if (isLongStackTrace) p2._pre = p1;
+        p1[p1._pCount++] = p2;
+
+        // 2.2.6
+        if (p1._s !== $pending)
+            scheduleHandler(p1, p2);
+
+        // 2.2.7
+        return p2;
+    }
+
+    // iterate tree
+    function hashOnRejected (node) {
+        // A node shouldn't be checked twice.
+        if (node._umark)
+            return true;
+        else
+            node._umark = true;
+
+        var i = 0
+        , len = node._pCount
+        , child;
+
+        while (i < len) {
+            child = node[i++];
+            if (child._onRejected || hashOnRejected(child)) return true;
+        }
+    }
+
+    function genStackInfo (reason, p) {
+        var stackInfo = [];
+
+        function trim (str) { return str.replace(/^\s+|\s+$/g, ""); }
+
+        function push (trace) {
+            return stackInfo.push(trim(trace));
+        }
+
+        if (isLongStackTrace && p[$promiseTrace]) {
+            if (p[$settlerTrace])
+                push(p[$settlerTrace]);
+
+            // Hope you guys could understand how the back trace works.
+            // We only have to iterate through the tree from the bottom to root.
+            (function iter (node) {
+                if (node) {
+                    iter(node._next);
+                    push(node[$promiseTrace]);
+                    iter(node._pre);
+                }
+            })(p);
+        }
+
+        return (isError(reason) ? reason.stack : reason)
+            + ("\n" + stackInfo.join("\n")).replace(/^.+\/node_modules\/yaku\/.+\n?/mg, "");
+    }
+
+    function callHanler (handler, value) {
+        // 2.2.5
+        return handler(value);
+    }
+
+    /**
+     * Resolve or reject a promise.
+     * @private
+     * @param  {Yaku} p
+     * @param  {Integer} state
+     * @param  {Any} value
+     */
+    function settlePromise (p, state, value) {
+        var i = 0
+        , len = p._pCount
+        , p2;
+
+        // 2.1.2
+        // 2.1.3
+        if (p._s === $pending) {
+            // 2.1.1.1
+            p._s = state;
+            p._v = value;
+
+            if (state === $rejected) {
+                if (isLongStackTrace && isError(value)) {
+                    value.longStack = genStackInfo(value, p);
+                }
+
+                scheduleUnhandledRejection(p);
+            }
+
+            // 2.2.4
+            while (i < len) {
+                p2 = p[i++];
+
+                if (p2._s !== $pending) continue;
+
+                scheduleHandler(p, p2);
+            }
+        }
+
+        return p;
+    }
+
+    /**
+     * Resolve or reject promise with value x. The x can also be a thenable.
+     * @private
+     * @param {Yaku} p
+     * @param {Any | Thenable} x A normal value or a thenable.
+     */
+    function settleWithX (p, x) {
+        // 2.3.1
+        if (x === p && x) {
+            settlePromise(p, $rejected, genTypeError($promiseCircularChain));
+            return p;
+        }
+
+        // 2.3.2
+        // 2.3.3
+        if (x !== $null && (isFunction(x) || isObject(x))) {
+            // 2.3.2.1
+            var xthen = genTryCatcher(getThen)(x);
+
+            if (xthen === $tryErr) {
+                // 2.3.3.2
+                settlePromise(p, $rejected, xthen.e);
+                return p;
+            }
+
+            if (isFunction(xthen)) {
+                if (isLongStackTrace && isYaku(x))
+                    p._next = x;
+
+                // Fix https://bugs.chromium.org/p/v8/issues/detail?id=4162
+                if (isYaku(x))
+                    settleXthen(p, x, xthen);
+                else
+                    Yaku.nextTick(function () {
+                        settleXthen(p, x, xthen);
+                    });
+            } else
+                // 2.3.3.4
+                settlePromise(p, $resolved, x);
+        } else
+            // 2.3.4
+            settlePromise(p, $resolved, x);
+
+        return p;
+    }
+
+    /**
+     * Try to get a promise's then method.
+     * @private
+     * @param  {Thenable} x
+     * @return {Function}
+     */
+    function getThen (x) { return x.then; }
+
+    /**
+     * Resolve then with its promise.
+     * @private
+     * @param  {Yaku} p
+     * @param  {Thenable} x
+     * @param  {Function} xthen
+     */
+    function settleXthen (p, x, xthen) {
+        // 2.3.3.3
+        var err = genTryCatcher(xthen, x)(function (y) {
+            // 2.3.3.3.3
+            if (x) {
+                x = $null;
+
+                // 2.3.3.3.1
+                settleWithX(p, y);
+            }
+        }, function (r) {
+            // 2.3.3.3.3
+            if (x) {
+                x = $null;
+
+                // 2.3.3.3.2
+                settlePromise(p, $rejected, r);
+            }
+        });
+
+        // 2.3.3.3.4.1
+        if (err === $tryErr && x) {
+            // 2.3.3.3.4.2
+            settlePromise(p, $rejected, err.e);
+            x = $null;
+        }
+    }
+
+})();


### PR DESCRIPTION
Continue after the #115. Sorry for so long. This time everything goes well. Only one file changed (92162b40f4cc6ee38a575ba5f28a82e90b4cf912), all the tests should pass.

When I debug the project, most of the unit test time is taken by the promise, it's unbearable for new contributors. Pulling the core code of promise out of the project will make the project more maintainable.

You don't have to run the `promises-aplus-tests` any more. Because as a separate project, yaku has already maintained the `promises-aplus-tests` on itself. So that you can focus on other parts of the project. Besides, I tested core-js against the [promises-es6-tests](https://github.com/promises-es6/promises-es6), it didn't pass all the tests. Yaku did pass them all.

With Yaku, the performance will be better, the error handling will be less painful (such as long stack trace support), the gzipped size of the core.min.js won't change (27KB).

Here's the comparison:

| name | unit tests | 1ms async task | optional helpers | helpers | min js |
| --- | --- | --- | --- | --- | --- |
| [yaku](https://github.com/ysmood/yaku)@0.11.6 | ✓ | 330ms / 106MB | ✓ | 29 | 3.8KB |
| [bluebird](https://github.com/petkaantonov/bluebird)@3.3.1 | x (18 failing) | 265ms / 88MB | partial | 100 | 52.2KB |
| [es6-promise](https://github.com/jakearchibald/es6-promise)@3.1.2 | x (52 failing) | 426ms / 113MB | x | 10 | 6.3KB |
| [native](http://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects)@0.12.4 | x ( 4 failing) | 590ms / 173MB | x | 13 | 0KB |
| [core-js](https://github.com/zloirock/core-js)@2.1.0 | x ( 4 failing) | 838ms / 198MB | x | 11 | 13.9KB |
| [es6-shim](https://github.com/paulmillr/es6-shim)@0.34.4 | ✓ | 950ms / 145MB | x | 12 | 130.8KB |
| [q](https://github.com/kriskowal/q)@1.4.1 | x (47 failing) | 1599ms / 425MB | x | 74 | 15.4KB |
