### PR TITLE
Fixes #173. Prevents RedExp.exec() crash in old Qt Script engine (WebKit) when using Symbol()

### DIFF
--- a/library/modules/es6.symbol.js
+++ b/library/modules/es6.symbol.js
@@ -54,10 +54,8 @@ var wrap = function(tag){
   sym._k = tag;
   DESCRIPTORS && setter && setSymbolDesc(ObjectProto, tag, {
     configurable: true,
-    set: function(value){
-      if(has(this, HIDDEN) && has(this[HIDDEN], tag))this[HIDDEN][tag] = false;
-      setSymbolDesc(this, tag, createDesc(1, value));
-    }
+    enumerable: false,
+    writable: true
   });
   return sym;
 };

--- a/modules/es6.symbol.js
+++ b/modules/es6.symbol.js
@@ -54,10 +54,8 @@ var wrap = function(tag){
   sym._k = tag;
   DESCRIPTORS && setter && setSymbolDesc(ObjectProto, tag, {
     configurable: true,
-    set: function(value){
-      if(has(this, HIDDEN) && has(this[HIDDEN], tag))this[HIDDEN][tag] = false;
-      setSymbolDesc(this, tag, createDesc(1, value));
-    }
+    enumerable: false,
+    writable: true
   });
   return sym;
 };


### PR DESCRIPTION
Symbol()'s call to Object.defineProperty() accessor descriptor should set a default 'get' property when adding a 'set' property. Prevents crash in old Qt Script engine (WebKit).