### PR TITLE
Fix Object.getOwnPropertyNames(window) replacement

### DIFF
--- a/library/modules/_object-gopn-ext.js
+++ b/library/modules/_object-gopn-ext.js
@@ -8,7 +8,7 @@ var windowNames = typeof window == 'object' && window && Object.getOwnPropertyNa
 
 var getWindowNames = function(it){
   try {
-    return gOPN.f(it);
+    return gOPN(it);
   } catch(e){
     return windowNames.slice();
   }

--- a/modules/_object-gopn-ext.js
+++ b/modules/_object-gopn-ext.js
@@ -8,7 +8,7 @@ var windowNames = typeof window == 'object' && window && Object.getOwnPropertyNa
 
 var getWindowNames = function(it){
   try {
-    return gOPN.f(it);
+    return gOPN(it);
   } catch(e){
     return windowNames.slice();
   }


### PR DESCRIPTION
There's an issue that would cause `Object.getOwnPropertyNames(window)` to return outdated results in some browsers. It would try to call the native `Object.getOwnPropertyNames` and then fall back, but there was a mistake in the try block so it would always fall back.

(This caused some really fun issues when mixing Babel code where some used the transform-runtime plugin and some didn't. Before I realized the cause of it was so simple, I started documenting this [example](https://github.com/AgentME/regenfail) because I imagined the fix would be much more involved.)