### PR TITLE
add `Symbol.asyncIterator`

### DIFF
--- a/es7/symbol.js
+++ b/es7/symbol.js
@@ -1,0 +1,2 @@
+require('../modules/es7.symbol.async-iterator');
+module.exports = require('../modules/_core').Symbol;

--- a/modules/es7.symbol.async-iterator.js
+++ b/modules/es7.symbol.async-iterator.js
@@ -1,0 +1,10 @@
+'use strict';
+// Symbol.asyncIterator shim
+var core    = require('./_core')
+  , wks     = require('./_wks')
+  , $Symbol = core.Symbol
+  , KEY     = 'asyncIterator'
+  , $DP     = require('./_object-dp')
+  , dP      = $DP.f;
+
+if(!(KEY in $Symbol))dP($Symbol, KEY, {value: wks(KEY)});


### PR DESCRIPTION
[Async iteration proposal](https://github.com/tc39/proposal-async-iteration) adds another popular symbol `Symbol.asyncIterator`, which is used for async for-of statement.

I'm not very familiar with sending PR to another repo, so please let me know if something is bad. :smile: 