### PR TITLE
v1.x.x backport request: Add a fallback for Chrome dev tools strange behavior

### DIFF
--- a/library/modules/$.iter-detect.js
+++ b/library/modules/$.iter-detect.js
@@ -13,7 +13,7 @@ module.exports = function(exec, skipClosing){
   try {
     var arr  = [7]
       , iter = arr[ITERATOR]();
-    iter.next = function(){ safe = true; };
+    iter.next = function(){ return {done: safe = true}; };
     arr[ITERATOR] = function(){ return iter; };
     exec(arr);
   } catch(e){ /* empty */ }

--- a/modules/$.iter-detect.js
+++ b/modules/$.iter-detect.js
@@ -13,7 +13,7 @@ module.exports = function(exec, skipClosing){
   try {
     var arr  = [7]
       , iter = arr[ITERATOR]();
-    iter.next = function(){ safe = true; };
+    iter.next = function(){ return {done: safe = true}; };
     arr[ITERATOR] = function(){ return iter; };
     exec(arr);
   } catch(e){ /* empty */ }


### PR DESCRIPTION
This pr aims to backport an already implemented fix (see #186) to the 1.x.x version track, for a breaking change introduced by the current stable version of Chrome.

_There doesn't seem to be a 1.x.x version track for core-js, but I thought I'd try to this request anyway._ 😉 

This could be seen as a critical bugfix, since babel 5.x.x still uses the core-js in the `^1.0.0` range. I can imagine quite a few devs who are maintaining an app with babel 5.x.x would appreciate this backport.

Also, thanks for the original fix! You've made it easy to apply a temporary hotfix to my own app.

**Note: I don't intend this pr to actually be merged into `master`. Perhaps you could create a `1.x.x` branch, if you go ahead with this pr?**