### PR TITLE
default iterator should not use native implementation when buggy

### DIFF
--- a/modules/_iter-define.js
+++ b/modules/_iter-define.js
@@ -30,7 +30,7 @@ module.exports = function(Base, NAME, Constructor, next, DEFAULT, IS_SET, FORCED
     , VALUES_BUG = false
     , proto      = Base.prototype
     , $native    = proto[ITERATOR] || proto[FF_ITERATOR] || DEFAULT && proto[DEFAULT]
-    , $default   = $native || getMethod(DEFAULT)
+    , $default   = (!BUGGY && $native) || getMethod(DEFAULT)
     , $entries   = DEFAULT ? !DEF_VALUES ? $default : getMethod('entries') : undefined
     , $anyNative = NAME == 'Array' ? proto.entries || $native : $native
     , methods, key, IteratorPrototype;


### PR DESCRIPTION
The fix for #236 (assuming the problem is valid)
