### PR TITLE
Add Promise#finally proposal Stage 2 TC39 0716

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 ##### Unreleased
 - Added `Math.{clamp, deg-per-rad, degrees, fscale, rad-per-deg, radians, scale}`, [stage 1 proposal](https://github.com/rwaldron/proposal-math-extensions), [#226](https://github.com/zloirock/core-js/issues/226)
+- Added `Promise#finally` [stage 2 proposal][https://github.com/tc39/proposal-promise-finally], [#225](https://github.com/zloirock/core-js/issues/225)
 
 ##### 2.4.1 - 2016.07.18
 - fixed `script` tag for some parsers, [#204](https://github.com/zloirock/core-js/issues/204), [#216](https://github.com/zloirock/core-js/issues/216)

--- a/README.md
+++ b/README.md
@@ -1446,6 +1446,15 @@ Symbol
 ```js
 core-js(/library)/fn/symbol/async-iterator
 ```
+* `Promise#finally` [proposal](https://github.com/tc39/proposal-promise-finally) - module [`es7.promise.finally`](https://github.com/zloirock/core-js/blob/v2.X.X/modules/es7.promise.finally.js)
+```js
+Promise
+  #finally(onFinally) -> Promise
+```
+[*CommonJS entry points:*](#commonjs)
+```js
+core-js(/library)/fn/promise/finally
+```
 
 #### Stage 1 proposals
 [*CommonJS entry points:*](#commonjs)

--- a/build/config.js
+++ b/build/config.js
@@ -153,6 +153,7 @@ module.exports = {
     'es7.object.define-setter',
     'es7.object.lookup-getter',
     'es7.object.lookup-setter',
+    'es7.promise.finally',
     'es7.map.to-json',
     'es7.set.to-json',
     'es7.system.global',

--- a/es7/index.js
+++ b/es7/index.js
@@ -14,6 +14,7 @@ require('../modules/es7.object.define-getter');
 require('../modules/es7.object.define-setter');
 require('../modules/es7.object.lookup-getter');
 require('../modules/es7.object.lookup-setter');
+require('../modules/es7.promise.finally');
 require('../modules/es7.map.to-json');
 require('../modules/es7.set.to-json');
 require('../modules/es7.system.global');

--- a/es7/promise.js
+++ b/es7/promise.js
@@ -1,0 +1,3 @@
+require('../modules/es6.promise');
+require('../modules/es7.promise.finally');
+module.exports = require('../modules/_core').Promise;

--- a/library/es7/index.js
+++ b/library/es7/index.js
@@ -14,6 +14,7 @@ require('../modules/es7.object.define-getter');
 require('../modules/es7.object.define-setter');
 require('../modules/es7.object.lookup-getter');
 require('../modules/es7.object.lookup-setter');
+require('../modules/es7.promise.finally');
 require('../modules/es7.map.to-json');
 require('../modules/es7.set.to-json');
 require('../modules/es7.system.global');

--- a/library/es7/promise.js
+++ b/library/es7/promise.js
@@ -1,6 +1,3 @@
-require('../modules/es6.object.to-string');
-require('../modules/es6.string.iterator');
-require('../modules/web.dom.iterable');
 require('../modules/es6.promise');
 require('../modules/es7.promise.finally');
 module.exports = require('../modules/_core').Promise;

--- a/library/fn/promise/finally.js
+++ b/library/fn/promise/finally.js
@@ -1,0 +1,2 @@
+require('../../modules/es7.promise.finally');
+module.exports = require('../../modules/_core').Promise.finally;

--- a/library/fn/promise/index.js
+++ b/library/fn/promise/index.js
@@ -1,0 +1,2 @@
+require('../../modules/es7.promise.finally');
+module.exports = require('../../modules/_core').Promise;

--- a/library/modules/es7.promise.finally.js
+++ b/library/modules/es7.promise.finally.js
@@ -1,0 +1,30 @@
+'use strict';
+// https://github.com/tc39/proposal-promise-finally
+var $export = require('./_export')
+  , core = require('./_core')
+  , global = require('./_global')
+  , speciesConstructor = require('./_species-constructor')
+  , $Promise = core.Promise || global.Promise;
+
+$export($export.P, 'Promise', {
+  'finally': function(onFinally){
+    var handler = typeof onFinally === 'function' ? onFinally : function(){};
+    var C = speciesConstructor(this, $Promise);
+    var newPromise = $Promise.prototype.then.call(
+      this, // throw if IsPromise(this) is not true
+      function(x) {
+        return new C(function(resolve) {
+          return resolve(handler());
+        })
+        .then(function(){ return x })
+      },
+      function(e) {
+        return new C(function(resolve) {
+          return resolve(handler());
+        })
+        .then(function(){ throw e; });
+      }
+    );
+    return newPromise;
+  }
+});

--- a/library/shim.js
+++ b/library/shim.js
@@ -151,6 +151,7 @@ require('./modules/es7.object.define-getter');
 require('./modules/es7.object.define-setter');
 require('./modules/es7.object.lookup-getter');
 require('./modules/es7.object.lookup-setter');
+require('./modules/es7.promise.finally');
 require('./modules/es7.map.to-json');
 require('./modules/es7.set.to-json');
 require('./modules/es7.system.global');

--- a/library/stage/2.js
+++ b/library/stage/2.js
@@ -1,3 +1,4 @@
+require('../modules/es7.promise.finally');
 require('../modules/es7.system.global');
 require('../modules/es7.symbol.async-iterator');
 module.exports = require('./3');

--- a/modules/es7.promise.finally.js
+++ b/modules/es7.promise.finally.js
@@ -1,0 +1,30 @@
+'use strict';
+// https://github.com/tc39/proposal-promise-finally
+var $export = require('./_export')
+  , core = require('./_core')
+  , global = require('./_global')
+  , speciesConstructor = require('./_species-constructor')
+  , $Promise = core.Promise || global.Promise;
+
+$export($export.P, 'Promise', {
+  'finally': function(onFinally){
+    var handler = typeof onFinally === 'function' ? onFinally : function(){};
+    var C = speciesConstructor(this, $Promise);
+    var newPromise = $Promise.prototype.then.call(
+      this, // throw if IsPromise(this) is not true
+      function(x) {
+        return new C(function(resolve) {
+          return resolve(handler());
+        })
+        .then(function(){ return x })
+      },
+      function(e) {
+        return new C(function(resolve) {
+          return resolve(handler());
+        })
+        .then(function(){ throw e; });
+      }
+    );
+    return newPromise;
+  }
+});

--- a/shim.js
+++ b/shim.js
@@ -151,6 +151,7 @@ require('./modules/es7.object.define-getter');
 require('./modules/es7.object.define-setter');
 require('./modules/es7.object.lookup-getter');
 require('./modules/es7.object.lookup-setter');
+require('./modules/es7.promise.finally');
 require('./modules/es7.map.to-json');
 require('./modules/es7.set.to-json');
 require('./modules/es7.system.global');

--- a/stage/2.js
+++ b/stage/2.js
@@ -1,3 +1,4 @@
 require('../modules/es7.system.global');
 require('../modules/es7.symbol.async-iterator');
+require('../modules/es7.promise.finally');
 module.exports = require('./3');

--- a/tests/commonjs.ls
+++ b/tests/commonjs.ls
@@ -29,6 +29,7 @@ for P in <[.. ../library]>
   ok require("#P/fn/object/define")({}, {q: 42}).q is 42
   ok require("#P/fn/object/make")([], {}) instanceof Array
   ok \isObject of require("#P/fn/object")
+  ok require("#P/fn/promise/finally") if \function
   ok require("#P/fn/function/bind")(((a, b)-> @ + a + b), 1 2)(3) is 6
   ok require("#P/fn/function/part")(((a, b, c)-> a + b + c), 2 3)(4) is 9
   ok require("#P/fn/function/virtual/bind").call(((a, b)-> @ + a + b), 1 2)(3) is 6

--- a/tests/library/es7.promise.finally.ls
+++ b/tests/library/es7.promise.finally.ls
@@ -1,0 +1,71 @@
+{module, test} = QUnit
+module \ES7
+
+{Promise} = core
+
+test 'Promise#finally' (assert)!->
+  assert.isFunction Promise::finally
+  assert.nonEnumerable Promise::, \finally
+  # subclassing, @@species pattern
+  promise = new Promise !-> it 42
+  promise@@ = FakePromise1 = !-> it ->, ->
+  FakePromise1[Symbol?species] = FakePromise2 = !-> it ->, ->
+  assert.ok promise.finally(->) instanceof FakePromise2, 'subclassing, @@species pattern'
+  # subclassing, incorrect `this.constructor` pattern
+  promise = new Promise !-> it 42
+  promise@@ = FakePromise1 = !-> it ->, ->
+  assert.ok promise.finally(->) instanceof Promise, 'subclassing, incorrect `this` pattern'
+  # NewPromiseCapability validations
+  promise = new Promise !-> it 42
+  promise@@ = FakePromise1 = !-> it ->, ->
+  FakePromise1[Symbol?species] = !->
+  assert.throws (!-> promise.finally(->)), 'NewPromiseCapability validations, #1'
+  FakePromise1[Symbol?species] = !-> it null, ->
+  assert.throws (!-> promise.finally(->)), 'NewPromiseCapability validations, #2'
+  FakePromise1[Symbol?species] = !-> it ->, null
+  assert.throws (!-> promise.finally(->)), 'NewPromiseCapability validations, #3'
+  #
+  # when value is returned, test finally is called, then onFulfilled is reached, not onRejected
+  # js:
+  # var finallyReached1 = false;
+  # var expectedValue1 = 1;
+  # var p1 = new Promise((resolve, reject) => resolve(expectedValue1));
+  # p1 = p1.finally(() => finallyReached1 = true;);
+  # p1.then(
+  #   val => {
+  #     assert.equal(finallyReached1, true);
+  #     assert.equal(value, expectedValue1);
+  #   },
+  #   reason => { assert.fail('onRejected should not be reached') });
+  #
+  # when exception is thrown, test finally is called, then onRejected is reached, not onFulfilled
+  # js:
+  # var finallyReached2 = false;
+  # var expectedReason1 = 1;
+  # var p2 = new Promise((resolve, reject) => reject(expectedReason1));
+  # p2 = p2.finally(() => finallyReached2 = true;);
+  # p2.then(
+  #   val => { assert.fail('onFulfilled should not be reached') },
+  #   reason => {
+  #     assert.equal(finallyReached2, true);
+  #     assert.equal(reason, expectedReason1);
+  #   });
+  #
+  # when onFinally is not a function nothing untoward happens
+  # var expectedValue2 = 1;
+  # var p1 = new Promise((resolve, reject) => resolve(expectedValue2));
+  # p1 = p1.finally(3);
+  # p1.then(
+  #   val => {
+  #     assert.equal(value, expectedValue2);
+  #   },
+  #   reason => { assert.fail('onRejected should not be reached') });
+  # var expectedReason2 = 1;
+  # var p2 = new Promise((resolve, reject) => reject(expectedReason2));
+  # p2 = p2.finally(3);
+  # p2.then(
+  #   val => { assert.fail('onFulfilled should not be reached') },
+  #   reason => {
+  #     assert.equal(reason, expectedReason2);
+  #   });
+  #

--- a/tests/tests/es7.promise.finally.ls
+++ b/tests/tests/es7.promise.finally.ls
@@ -1,0 +1,71 @@
+{module, test} = QUnit
+module \ES7
+
+test 'Promise#finally' (assert)!->
+  assert.isFunction Promise::finally
+  NATIVE and assert.arity Promise::finally, 2
+  assert.looksNative Promise::finally
+  assert.nonEnumerable Promise::, \finally
+  # subclassing, @@species pattern
+  promise = new Promise !-> it 42
+  promise@@ = FakePromise1 = !-> it ->, ->
+  FakePromise1[Symbol?species] = FakePromise2 = !-> it ->, ->
+  assert.ok promise.finally(->) instanceof FakePromise2, 'subclassing, @@species pattern'
+  # subclassing, incorrect `this.constructor` pattern
+  promise = new Promise !-> it 42
+  promise@@ = FakePromise1 = !-> it ->, ->
+  assert.ok promise.finally(->) instanceof Promise, 'subclassing, incorrect `this` pattern'
+  # NewPromiseCapability validations
+  promise = new Promise !-> it 42
+  promise@@ = FakePromise1 = !-> it ->, ->
+  FakePromise1[Symbol?species] = !->
+  assert.throws (!-> promise.finally(->)), 'NewPromiseCapability validations, #1'
+  FakePromise1[Symbol?species] = !-> it null, ->
+  assert.throws (!-> promise.finally(->)), 'NewPromiseCapability validations, #2'
+  FakePromise1[Symbol?species] = !-> it ->, null
+  assert.throws (!-> promise.finally(->)), 'NewPromiseCapability validations, #3'
+  #
+  # when value is returned, test finally is called, then onFulfilled is reached, not onRejected
+  # js:
+  # var finallyReached1 = false;
+  # var expectedValue1 = 1;
+  # var p1 = new Promise((resolve, reject) => resolve(expectedValue1));
+  # p1 = p1.finally(() => finallyReached1 = true;);
+  # p1.then(
+  #   val => {
+  #     assert.equal(finallyReached1, true);
+  #     assert.equal(value, expectedValue1);
+  #   },
+  #   reason => { assert.fail('onRejected should not be reached') });
+  #
+  # when exception is thrown, test finally is called, then onRejected is reached, not onFulfilled
+  # js:
+  # var finallyReached2 = false;
+  # var expectedReason1 = 1;
+  # var p2 = new Promise((resolve, reject) => reject(expectedReason1));
+  # p2 = p2.finally(() => finallyReached2 = true;);
+  # p2.then(
+  #   val => { assert.fail('onFulfilled should not be reached') },
+  #   reason => {
+  #     assert.equal(finallyReached2, true);
+  #     assert.equal(reason, expectedReason1);
+  #   });
+  #
+  # when onFinally is not a function nothing untoward happens
+  # var expectedValue2 = 1;
+  # var p1 = new Promise((resolve, reject) => resolve(expectedValue2));
+  # p1 = p1.finally(3);
+  # p1.then(
+  #   val => {
+  #     assert.equal(value, expectedValue2);
+  #   },
+  #   reason => { assert.fail('onRejected should not be reached') });
+  # var expectedReason2 = 1;
+  # var p2 = new Promise((resolve, reject) => reject(expectedReason2));
+  # p2 = p2.finally(3);
+  # p2.then(
+  #   val => { assert.fail('onFulfilled should not be reached') },
+  #   reason => {
+  #     assert.equal(reason, expectedReason2);
+  #   });
+  #


### PR DESCRIPTION
## [Promise#finally proposal Stage 2 from TC39 meeting on 2016-07](https://github.com/rwaldron/tc39-notes/blob/master/es7/2016-07/jul-28.md#10iiib-promiseprototypefinally).
- [proposal](https://github.com/rwaldron/tc39-notes/blob/master/es7/2016-07/jul-28.md#10iiib-promiseprototypefinally)
- [polyfill](https://github.com/tc39/proposal-promise-finally/blob/master/polyfill.js)

Used implementation of `String#padStart`, `String#trimLeft`, and `Promise#then` as examples. 
## Initial open items
- [X] Not able to use `finally` for the function name, perhaps because it is a reserved keyword. Temporarily used `_finally` for implementation and test (commented below).
- [X] Did not use polyfill's method of setting species. Coded to assume `core-js` Promise polyfill will set species, but, if I'm not mistaken, it's possible that `finally` may be `require`d without the Promise polyfill. Since `core-js` has its own method of setting species, what should be done?
- [ ] The failing test is precisely about Promise not having the right species (I think), but I'm not sure why, it shows up in the commonjs test for `delay`
  ![image](https://cloud.githubusercontent.com/assets/3524633/18235332/6136d86e-72df-11e6-98cf-71a51be870be.png)
- [ ] The `finally` implementation is not in an internal file, but directly in the imported one. I am not supposing that it would be used by other functions in the library. Should I rather assume that it may be?
