### PR TITLE
Incomplete iterable DOM changes for discussion

### DIFF
--- a/modules/library/web.dom.iterable.js
+++ b/modules/library/web.dom.iterable.js
@@ -1,10 +1,19 @@
 require('./es6.array.iterator');
 var global        = require('./_global')
+  , getKeys       = require('./_object-keys')
   , hide          = require('./_hide')
   , Iterators     = require('./_iterators')
   , TO_STRING_TAG = require('./_wks')('toStringTag');
 
-for(var collections = ['NodeList', 'DOMTokenList', 'MediaList', 'StyleSheetList', 'CSSRuleList'], i = 0; i < 5; i++){
+var DOMIterables = {
+  CSSRuleList: true, // TODO: Not spec compliant, should be false.
+  DOMTokenList: true,
+  MediaList: true, // TODO: Not spec compliant, should be false.
+  NodeList: true,
+  StyleSheetList: true // TODO: Not spec compliant, should be false.
+};
+
+for(var collections = getKeys(DOMIterables), i = 0; i < collections.length; i++){
   var NAME       = collections[i]
     , Collection = global[NAME]
     , proto      = Collection && Collection.prototype;

--- a/modules/library/web.dom.iterable.js
+++ b/modules/library/web.dom.iterable.js
@@ -7,10 +7,36 @@ var global        = require('./_global')
 
 var DOMIterables = {
   CSSRuleList: true, // TODO: Not spec compliant, should be false.
+  CSSStyleDeclaration: false,
+  CSSValueList: false,
+  ClientRectList: false,
+  DOMRectList: false,
+  DOMStringList: false,
   DOMTokenList: true,
+  DataTransferItemList: false,
+  FileList: false,
+  HTMLAllCollection: false,
+  HTMLCollection: false,
+  HTMLFormElement: false,
+  HTMLSelectElement: false,
   MediaList: true, // TODO: Not spec compliant, should be false.
+  MimeTypeArray: false,
+  NamedNodeMap: false,
   NodeList: true,
-  StyleSheetList: true // TODO: Not spec compliant, should be false.
+  PaintRequestList: false,
+  Plugin: false,
+  PluginArray: false,
+  SVGLengthList: false,
+  SVGNumberList: false,
+  SVGPathSegList: false,
+  SVGPointList: false,
+  SVGStringList: false,
+  SVGTransformList: false,
+  SourceBufferList: false,
+  StyleSheetList: true, // TODO: Not spec compliant, should be false.
+  TextTrackCueList: false,
+  TextTrackList: false,
+  TouchList: false
 };
 
 for(var collections = getKeys(DOMIterables), i = 0; i < collections.length; i++){

--- a/modules/web.dom.iterable.js
+++ b/modules/web.dom.iterable.js
@@ -1,4 +1,5 @@
 var $iterators    = require('./es6.array.iterator')
+  , getKeys       = require('./_object-keys')
   , redefine      = require('./_redefine')
   , global        = require('./_global')
   , hide          = require('./_hide')
@@ -8,8 +9,17 @@ var $iterators    = require('./es6.array.iterator')
   , TO_STRING_TAG = wks('toStringTag')
   , ArrayValues   = Iterators.Array;
 
-for(var collections = ['NodeList', 'DOMTokenList', 'MediaList', 'StyleSheetList', 'CSSRuleList'], i = 0; i < 5; i++){
+var DOMIterables = {
+  CSSRuleList: true, // TODO: Not spec compliant, should be false.
+  DOMTokenList: true,
+  MediaList: true, // TODO: Not spec compliant, should be false.
+  NodeList: true,
+  StyleSheetList: true // TODO: Not spec compliant, should be false.
+};
+
+for(var collections = getKeys(DOMIterables), i = 0; i < collections.length; i++){
   var NAME       = collections[i]
+    , explicit   = DOMIterables[NAME]
     , Collection = global[NAME]
     , proto      = Collection && Collection.prototype
     , key;
@@ -17,6 +27,6 @@ for(var collections = ['NodeList', 'DOMTokenList', 'MediaList', 'StyleSheetList'
     if(!proto[ITERATOR])hide(proto, ITERATOR, ArrayValues);
     if(!proto[TO_STRING_TAG])hide(proto, TO_STRING_TAG, NAME);
     Iterators[NAME] = ArrayValues;
-    for(key in $iterators)if(!proto[key])redefine(proto, key, $iterators[key], true);
+    if (explicit)for(key in $iterators)if(!proto[key])redefine(proto, key, $iterators[key], true);
   }
 }

--- a/modules/web.dom.iterable.js
+++ b/modules/web.dom.iterable.js
@@ -11,10 +11,36 @@ var $iterators    = require('./es6.array.iterator')
 
 var DOMIterables = {
   CSSRuleList: true, // TODO: Not spec compliant, should be false.
+  CSSStyleDeclaration: false,
+  CSSValueList: false,
+  ClientRectList: false,
+  DOMRectList: false,
+  DOMStringList: false,
   DOMTokenList: true,
+  DataTransferItemList: false,
+  FileList: false,
+  HTMLAllCollection: false,
+  HTMLCollection: false,
+  HTMLFormElement: false,
+  HTMLSelectElement: false,
   MediaList: true, // TODO: Not spec compliant, should be false.
+  MimeTypeArray: false,
+  NamedNodeMap: false,
   NodeList: true,
-  StyleSheetList: true // TODO: Not spec compliant, should be false.
+  PaintRequestList: false,
+  Plugin: false,
+  PluginArray: false,
+  SVGLengthList: false,
+  SVGNumberList: false,
+  SVGPathSegList: false,
+  SVGPointList: false,
+  SVGStringList: false,
+  SVGTransformList: false,
+  SourceBufferList: false,
+  StyleSheetList: true, // TODO: Not spec compliant, should be false.
+  TextTrackCueList: false,
+  TextTrackList: false,
+  TouchList: false
 };
 
 for(var collections = getKeys(DOMIterables), i = 0; i < collections.length; i++){

--- a/tests/library/web.dom.iterable.ls
+++ b/tests/library/web.dom.iterable.ls
@@ -3,7 +3,12 @@ module 'Web'
 
 test 'Iterable DOM collections' (assert)!->
   absent = on;
-  for <[NodeList DOMTokenList MediaList StyleSheetList CSSRuleList]>
+  for <[CSSRuleList CSSStyleDeclaration CSSValueList ClientRectList DOMRectList
+    DOMStringList DOMTokenList DataTransferItemList FileList HTMLAllCollection
+    HTMLCollection HTMLFormElement HTMLSelectElement MediaList
+    MimeTypeArray NamedNodeMap NodeList PaintRequestList Plugin PluginArray SVGLengthList
+    SVGNumberList SVGPathSegList SVGPointList SVGStringList SVGTransformList
+    SourceBufferList StyleSheetList TextTrackCueList TextTrackList TouchList]>
     Collection = global[..]
     if Collection
       assert.same Collection::[core.Symbol.toStringTag], .., "#{..}::@@toStringTag is '#{..}'"

--- a/tests/tests/web.dom.iterable.ls
+++ b/tests/tests/web.dom.iterable.ls
@@ -12,6 +12,22 @@ test 'Iterable DOM collections' (assert)->
       assert.isFunction Collection::keys, "#{..}::@@keys is function"
       assert.isFunction Collection::entries, "#{..}::@@entries is function"
       absent = no
+
+  for <[CSSStyleDeclaration CSSValueList ClientRectList DOMRectList
+    DOMStringList DataTransferItemList FileList HTMLAllCollection
+    HTMLCollection HTMLFormElement HTMLSelectElement
+    MimeTypeArray NamedNodeMap PaintRequestList Plugin PluginArray SVGLengthList
+    SVGNumberList SVGPathSegList SVGPointList SVGStringList SVGTransformList
+    SourceBufferList TextTrackCueList TextTrackList TouchList]>
+    Collection = global[..]
+    if Collection
+      assert.same Collection::[Symbol?toStringTag], .., "#{..}::@@toStringTag is '#{..}'"
+      assert.isFunction Collection::[Symbol?iterator], "#{..}::@@iterator is function"
+      assert.notOk Collection::values, "#{..}::@@values is not function"
+      assert.notOk Collection::keys, "#{..}::@@keys is not function"
+      assert.notOk Collection::entries, "#{..}::@@entries is not function"
+      absent = no
+
   if NodeList? and document?querySelectorAll and document.querySelectorAll(\div) instanceof NodeList
     assert.isFunction document.querySelectorAll(\div)[Symbol.iterator], 'works with document.querySelectorAll'
   if absent => assert.ok on, 'DOM collections are absent'


### PR DESCRIPTION
Posting for discussion given https://github.com/babel/babel/issues/4616. Not a complete fix because I wanted to get your thoughts before going further.

As far as I can tell, and given the behavior in Chrome and FF, these are supposed to be iterable because of the behavior documented in https://heycam.github.io/webidl/#es-iterators for IDL. It says any integer-indexed class should be considered iterable automatically, but only those explicitly marked `Iterable` in the IDL should get `keys`, `values` and `entries`.

Given that, the current behavior of of MediaList, StyleSheetList, and CSSRuleList aren't quite right since they should not have an `.keys`, `.values` and `.entries`. Only NodeList and DOMTokenList are explicitly `Iterable<>` in the DOM spec.

I've pulled in a list of DOM classes that are currently iterable in Chrome/FF and merged them together with a bit of cleanup. This covers HTMLCollection and NamedNodeMap, which are probably the main important ones people are likely to want to use.
