### PR TITLE
Fixed a bug where core-js was modifying native collection iterator prototypes

### DIFF
--- a/modules/_iter-define.js
+++ b/modules/_iter-define.js
@@ -41,7 +41,10 @@ module.exports = function(Base, NAME, Constructor, next, DEFAULT, IS_SET, FORCED
       // Set @@toStringTag to native iterators
       setToStringTag(IteratorPrototype, TAG, true);
       // fix for some old engines
-      if(!LIBRARY && !has(IteratorPrototype, ITERATOR))hide(IteratorPrototype, ITERATOR, returnThis);
+      if(!LIBRARY && !has(getPrototypeOf(IteratorPrototype), ITERATOR)
+        && getPrototypeOf(IteratorPrototype) !== Object.prototype) {
+        hide(getPrototypeOf(IteratorPrototype), ITERATOR, returnThis);
+      }
     }
   }
   // fix Array#{values, @@iterator}.name in V8 / FF

--- a/modules/_iter-define.js
+++ b/modules/_iter-define.js
@@ -33,17 +33,32 @@ module.exports = function(Base, NAME, Constructor, next, DEFAULT, IS_SET, FORCED
     , $default   = $native || getMethod(DEFAULT)
     , $entries   = DEFAULT ? !DEF_VALUES ? $default : getMethod('entries') : undefined
     , $anyNative = NAME == 'Array' ? proto.entries || $native : $native
-    , methods, key, IteratorPrototype;
+    , methods, key, IteratorPrototype, IteratorPrototypePrototype;
   // Fix native
   if($anyNative){
     IteratorPrototype = getPrototypeOf($anyNative.call(new Base));
     if(IteratorPrototype !== Object.prototype){
       // Set @@toStringTag to native iterators
       setToStringTag(IteratorPrototype, TAG, true);
-      // fix for some old engines
-      if(!LIBRARY && !has(getPrototypeOf(IteratorPrototype), ITERATOR)
-        && getPrototypeOf(IteratorPrototype) !== Object.prototype) {
-        hide(getPrototypeOf(IteratorPrototype), ITERATOR, returnThis);
+      // according to the ES2015 standard, iterators for Map, Set, Array, and String
+      // should have a prototype of %MapIteratorPrototype%, %SetIteratorPrototype%,
+      // %ArrayIteratorPrototype%, and %StringIteratorPrototype%, respectively, and
+      // each of *those* should have a prototype of %IteratorPrototype%.
+      // however, some older engines don't have %IteratorPrototype%, which means that
+      // an iterator instance won't have an @@iterator property, which is a bug.
+      // in addition, some of those older engines don't allow setPrototypeOf, so you can't
+      // just change the prototype chain. the solution here is to put @@iterator on
+      // the %(Map|Set\Array|String)IteratorPrototype%, which is not strictly correct,
+      // but to only do so in engines where we know the prototype chain is wrong.
+
+      // IteratorPrototypePrototype is %IteratorPrototype% in standards-compliant
+      // browsers.
+      IteratorPrototypePrototype = getPrototypeOf(IteratorPrototype)
+      if(!LIBRARY && IteratorPrototypePrototype && !has(IteratorPrototypePrototype, ITERATOR)){
+        // this is a browser that doesn't correctly support %IteratorPrototype%, so
+        // we put the @@iterator property on %(Map|Set|Array|String)IteratorPrototype%
+        // instead.
+        hide(IteratorPrototype, ITERATOR, returnThis);
       }
     }
   }

--- a/tests/library/es6.array.iterator.ls
+++ b/tests/library/es6.array.iterator.ls
@@ -3,12 +3,17 @@ module \ES6
 
 {Symbol} = core
 {keys, values, entries} = core.Array
+{getPrototypeOf} = core.Object
 
 test 'Array#@@iterator' (assert)!->
   assert.isFunction values
   iter = core.getIterator <[q w e]>
   assert.isIterator iter
   assert.isIterable iter
+  assert.strictEqual iter, iter[Symbol?iterator]()
+  assert.notOk iter.hasOwnProperty(Symbol?iterator)
+  assert.notOk getPrototypeOf(iter).hasOwnProperty(Symbol?iterator)
+  assert.ok getPrototypeOf(getPrototypeOf(iter)).hasOwnProperty(Symbol?iterator)
   assert.strictEqual iter[Symbol?toStringTag], 'Array Iterator'
   assert.deepEqual iter.next!, {value: \q, done: no}
   assert.deepEqual iter.next!, {value: \w, done: no}

--- a/tests/library/es6.map.ls
+++ b/tests/library/es6.map.ls
@@ -3,7 +3,7 @@ module \ES6
 
 same = (a, b)-> if a is b => a isnt 0 or 1 / a is 1 / b else a !~= a and b !~= b
 {Map, Set, Symbol} = core
-{getOwnPropertyDescriptor, freeze} = core.Object
+{getOwnPropertyDescriptor, freeze, getPrototypeOf} = core.Object
 {iterator} = core.Symbol
 
 test 'Map' (assert)!->
@@ -246,6 +246,10 @@ test 'Map#@@iterator' (assert)!->
   iter = core.getIterator new Map [[\a \q],[\s \w],[\d \e]]
   assert.isIterator iter
   assert.isIterable iter
+  assert.strictEqual iter, iter[Symbol?iterator]()
+  assert.notOk iter.hasOwnProperty(Symbol?iterator)
+  assert.notOk getPrototypeOf(iter).hasOwnProperty(Symbol?iterator)
+  assert.ok getPrototypeOf(getPrototypeOf(iter)).hasOwnProperty(Symbol?iterator)
   assert.strictEqual iter[Symbol?toStringTag], 'Map Iterator'
   assert.deepEqual iter.next!, {value: [\a \q], done: no}
   assert.deepEqual iter.next!, {value: [\s \w], done: no}

--- a/tests/library/es6.set.ls
+++ b/tests/library/es6.set.ls
@@ -3,7 +3,7 @@ module \ES6
 
 same = (a, b)-> if a is b => a isnt 0 or 1 / a is 1 / b else a !~= a and b !~= b
 {Set, Map, Symbol} = core
-{getOwnPropertyDescriptor, freeze} = core.Object
+{getOwnPropertyDescriptor, freeze, getPrototypeOf} = core.Object
 {iterator} = core.Symbol
 
 test 'Set' (assert)!->
@@ -237,6 +237,10 @@ test 'Set#@@iterator' (assert)!->
   iter = core.getIterator(new Set <[q w e]>)
   assert.isIterator iter
   assert.isIterable iter
+  assert.strictEqual iter, iter[Symbol?iterator]()
+  assert.notOk iter.hasOwnProperty(Symbol?iterator)
+  assert.notOk getPrototypeOf(iter).hasOwnProperty(Symbol?iterator)
+  assert.ok getPrototypeOf(getPrototypeOf(iter)).hasOwnProperty(Symbol?iterator)
   assert.strictEqual iter[Symbol?toStringTag], 'Set Iterator'
   assert.deepEqual iter.next!, {value: \q, done: no}
   assert.deepEqual iter.next!, {value: \w, done: no}

--- a/tests/library/es6.string.iterator.ls
+++ b/tests/library/es6.string.iterator.ls
@@ -1,9 +1,16 @@
 {module, test} = QUnit
 module \ES6
 
+{Symbol} = core
+{getPrototypeOf} = core.Object
+
 test 'String#@@iterator' (assert)!->
   iter = core.getIterator 'qwe'
   assert.isIterator iter
+  assert.strictEqual iter, iter[Symbol?iterator]()
+  assert.notOk iter.hasOwnProperty(Symbol?iterator)
+  assert.notOk getPrototypeOf(iter).hasOwnProperty(Symbol?iterator)
+  assert.ok getPrototypeOf(getPrototypeOf(iter)).hasOwnProperty(Symbol?iterator)
   assert.strictEqual iter[core.Symbol?toStringTag], 'String Iterator'
   assert.deepEqual iter.next!, {value: \q, done: no}
   assert.deepEqual iter.next!, {value: \w, done: no}


### PR DESCRIPTION
First off, thanks for all the hard work that has gone into `core-js`!

I ran into a fairly obscure bug in `core-js`'s handling of collection iterator prototype chains while running [compat-table](https://github.com/kangax/compat-table) tests on various platforms. I found that `core-js` was causing collection iterator prototype chain tests to fail on platforms that already had native collection iterator support. The tests that were failing are for iterators on Set, Map, Array, and String, and they all look basically like this:

```
function test() {
        // Iterator instance
        var iterator = ''[Symbol.iterator]();
        // %StringIteratorPrototype%
        var proto1 = Object.getPrototypeOf(iterator);
        // %IteratorPrototype%
        var proto2 = Object.getPrototypeOf(proto1);

        return proto2.hasOwnProperty(Symbol.iterator) &&
          !proto1    .hasOwnProperty(Symbol.iterator) &&
          !iterator  .hasOwnProperty(Symbol.iterator) &&
          iterator[Symbol.iterator]() === iterator;
}
```

As this test shows, the iterator should not have a `Symbol.iterator` own property, and neither should the iterator's prototype. The iterator's prototype's prototype, however, **should** have a `Symbol.iterator` property, and that method should return the iterator. These tests pass in all modern browsers without any shims (Chrome, Firefox, Safari). They also pass when `core-js` is used in a browser that has no iterator support. These tests fail, however, when used in modern browsers in concert with `core-js`.

It looks to me like there is a method in `_iter-define.js` that attempts to patch the iterator prototype chain for native iterator implementations only, but the implementation puts a `Symbol.iterator` method on the iterator's prototype rather than the iterator's prototype's prototype. This is what causes the test failures.

This PR attempts to fix this by patching the native iterator's prototype's prototype instead. I added tests for Set, Map, Array, and String, although those tests didn't fail with the pre-existing code. I think this because `npm run test` runs the test suite in Phantom, which doesn't have native iterator support. As I said above, this bug only shows up in browsers that have native iterator support.

Apologies for any breaches of code style and such; I've never used LiveScript before and did not feel super confident about my changes there. Feedback is welcome, and thanks again for your work!

