### PR TITLE
Don't set Symbol when loading asyncIterator

### DIFF
--- a/library/modules/_wks-define.js
+++ b/library/modules/_wks-define.js
@@ -4,6 +4,9 @@ var global         = require('./_global')
   , wksExt         = require('./_wks-ext')
   , defineProperty = require('./_object-dp').f;
 module.exports = function(name){
-  var $Symbol = core.Symbol || (core.Symbol = LIBRARY ? {} : global.Symbol || {});
-  if(name.charAt(0) != '_' && !(name in $Symbol))defineProperty($Symbol, name, {value: wksExt.f(name)});
+  var $Symbol = core.Symbol || (LIBRARY ? null : global.Symbol);
+  if(name.charAt(0) != '_') {
+    if($Symbol && !(name in $Symbol))defineProperty($Symbol, name, {value: wksExt.f(name)});
+    else wksExt.f(name);
+  }
 };

--- a/modules/_wks-define.js
+++ b/modules/_wks-define.js
@@ -4,6 +4,9 @@ var global         = require('./_global')
   , wksExt         = require('./_wks-ext')
   , defineProperty = require('./_object-dp').f;
 module.exports = function(name){
-  var $Symbol = core.Symbol || (core.Symbol = LIBRARY ? {} : global.Symbol || {});
-  if(name.charAt(0) != '_' && !(name in $Symbol))defineProperty($Symbol, name, {value: wksExt.f(name)});
+  var $Symbol = core.Symbol || (LIBRARY ? null : global.Symbol);
+  if(name.charAt(0) != '_') {
+    if($Symbol && !(name in $Symbol))defineProperty($Symbol, name, {value: wksExt.f(name)});
+    else wksExt.f(name);
+  }
 };


### PR DESCRIPTION
Fixes https://github.com/zloirock/core-js/issues/262, though I'm not sure how to test that.

Does this look right? This code doesn't seem to need to change `core.Symbol` if `core.Symbol` doesn't already exist, and the module building `core.Symbol` will pick up everything defined on `wks.store` anyway.