### PR TITLE
Add support for Sphere Dispatch API

### DIFF
--- a/modules/_task.js
+++ b/modules/_task.js
@@ -7,6 +7,7 @@ var ctx                = require('./_ctx')
   , setTask            = global.setImmediate
   , clearTask          = global.clearImmediate
   , MessageChannel     = global.MessageChannel
+  , Dispatch           = global.Dispatch
   , counter            = 0
   , queue              = {}
   , ONREADYSTATECHANGE = 'onreadystatechange'
@@ -40,6 +41,11 @@ if(!setTask || !clearTask){
   if(require('./_cof')(process) == 'process'){
     defer = function(id){
       process.nextTick(ctx(run, id, 1));
+    };
+  // Sphere (JS game engine) Dispatch API
+  } else if(Dispatch && Dispatch.now){
+    defer = function(id){
+      Dispatch.now(ctx(run, id, 1));
     };
   // Browsers with MessageChannel, includes WebWorkers
   } else if(MessageChannel){


### PR DESCRIPTION
[miniSphere](https://github.com/fatcerberus/minisphere) is JavaScript game engine maintained by myself and using the Duktape ES5 engine.  My environment doesn't have any of the async harnesses (setTimeout, postMessage, etc.) supported by browsers, but *does* have a function, `Dispatch.now()`, that serves the same purpose.  the core-js Promise implementation doesn't currently work in my environment because of this; this pull adds support for it.