### PR TITLE
Wrapped fn Array.from export in a function, so the context of the exp…

### DIFF
--- a/library/fn/array/from.js
+++ b/library/fn/array/from.js
@@ -1,3 +1,6 @@
 require('../../modules/es6.string.iterator');
 require('../../modules/es6.array.from');
-module.exports = require('../../modules/_core').Array.from;
+var arrayfrom = require('../../modules/_core').Array.from;
+module.exports = function (arrayLike, mapFn, thisArg) {
+  return arrayfrom(arrayLike, mapFn, thisArg);
+};


### PR DESCRIPTION
…orted function is not tampered with in webpack3 (will fix webpack/webpack#5135)

I dont know why EXACTLY this issue happens in webpack, but it can be reproduced with such short snippet:
```js
var req = function () { return Array.from }
Object.defineProperty(req, 'a', { get: req })
req.a([1,2])
```

I've tried to tamper with `this` by calling `Array.from` in many, many forms but I couldnt break it otherwise and I dont quite get whats exactly happening here. If you know the answer, please share.

This is caused by `babel-runtime`'s usage of the `core-js` (probably when people use `transform-runtime`) when bundling code with webpack3 due to how it wraps the modules.