### PR TITLE
Make link to CONTRIBUTING.md absolute

### DIFF
--- a/packages/core-js-compat/README.md
+++ b/packages/core-js-compat/README.md
@@ -34,4 +34,4 @@ console.log(targets);
 */
 ```
 
-If you want to add new / update data about modules required for target engines, [follow this instruction](../../CONTRIBUTING.md#updating-core-js-compat-data).
+If you want to add new / update data about modules required for target engines, [follow this instruction](https://github.com/zloirock/core-js/blob/master/CONTRIBUTING.md#updating-core-js-compat-data).


### PR DESCRIPTION
Otherwise, the link is broken on `core-js-compat` npm page: https://www.npmjs.com/package/core-js-compat