### PR TITLE
Fix duplicated assignment to module.exports

### DIFF
--- a/packages/core-js/features/array/flat-map.js
+++ b/packages/core-js/features/array/flat-map.js
@@ -1,1 +1,1 @@
-module.exports = module.exports = require('../../es/array/flat-map');
+module.exports = require('../../es/array/flat-map');

--- a/packages/core-js/features/array/flat.js
+++ b/packages/core-js/features/array/flat.js
@@ -1,1 +1,1 @@
-module.exports = module.exports = require('../../es/array/flat');
+module.exports = require('../../es/array/flat');

--- a/packages/core-js/features/object/index.js
+++ b/packages/core-js/features/object/index.js
@@ -1,1 +1,1 @@
-module.exports = module.exports = require('../../es/object');
+module.exports = require('../../es/object');

--- a/packages/core-js/stable/array/flat-map.js
+++ b/packages/core-js/stable/array/flat-map.js
@@ -1,1 +1,1 @@
-module.exports = module.exports = require('../../es/array/flat-map');
+module.exports = require('../../es/array/flat-map');

--- a/packages/core-js/stable/array/flat.js
+++ b/packages/core-js/stable/array/flat.js
@@ -1,1 +1,1 @@
-module.exports = module.exports = require('../../es/array/flat');
+module.exports = require('../../es/array/flat');

--- a/packages/core-js/stable/object/index.js
+++ b/packages/core-js/stable/object/index.js
@@ -1,1 +1,1 @@
-module.exports = module.exports = require('../../es/object');
+module.exports = require('../../es/object');


### PR DESCRIPTION
While looking through the code, I found some duplicated `module.exports` assignments, which were probably copy-paste errors. This PR replaces them all :spaghetti: 