### PR TITLE
Give correct RegExp flags in toString

### DIFF
--- a/packages/core-js/modules/es.regexp.to-string.js
+++ b/packages/core-js/modules/es.regexp.to-string.js
@@ -2,9 +2,9 @@
 var anObject = require('../internals/an-object');
 var fails = require('../internals/fails');
 var flags = require('../internals/regexp-flags');
-var DESCRIPTORS = require('../internals/descriptors');
 var TO_STRING = 'toString';
 var nativeToString = /./[TO_STRING];
+var RegExpPrototype = RegExp.prototype;
 
 var NOT_GENERIC = fails(function () { return nativeToString.call({ source: 'a', flags: 'b' }) != '/a/b'; });
 // FF44- RegExp#toString has a wrong name
@@ -15,7 +15,8 @@ var INCORRECT_NAME = nativeToString.name != TO_STRING;
 if (NOT_GENERIC || INCORRECT_NAME) {
   require('../internals/redefine')(RegExp.prototype, TO_STRING, function toString() {
     var R = anObject(this);
+    var rf = R.flags;
     return '/'.concat(R.source, '/',
-      'flags' in R ? R.flags : !DESCRIPTORS && R instanceof RegExp ? flags.call(R) : undefined);
+      rf == null && R instanceof RegExp && !('flags' in RegExpPrototype) ? flags.call(R) : rf);
   }, { unsafe: true });
 }

--- a/tests/tests/es.regexp.to-string.js
+++ b/tests/tests/es.regexp.to-string.js
@@ -22,6 +22,11 @@ QUnit.test('RegExp#toString', assert => {
     flags: 'bar',
   }), '/foo/bar');
   assert.same(toString.call({}), '/undefined/undefined');
+  assert.same(toString.call(new Proxy(/pattern/, {
+    get(object, key) {
+      return key === 'flags' ? 'x' : object[key];
+    },
+  })), '/pattern/x');
   if (STRICT) {
     assert.throws(() => toString.call(7));
     assert.throws(() => toString.call('a'));


### PR DESCRIPTION
When the flags property is not available on `RegExp`, the internals `regexp-flags` implementation should be used regardless of `DESCRIPTORS`.

Fixes: zloirock/core-js#536

I'm not *certain* this is the right fix, but the value of `DESCRIPTORS` is `true` on IE 11 and the internals implementation would be fine - and doesn't seem to depend on `defineProperty`.

Also not sure how to include a focused test, but the linked issue has a project that reproduces the problem.