### PR TITLE
Adds workaround for rollup treeshaking issue

### DIFF
--- a/packages/core-js/modules/es.object.get-own-property-names.js
+++ b/packages/core-js/modules/es.object.get-own-property-names.js
@@ -1,5 +1,5 @@
 var nativeGetOwnPropertyNames = require('../internals/object-get-own-property-names-external').f;
-var FAILS_ON_PRIMITIVES = require('../internals/fails')(function () { Object.getOwnPropertyNames(1); });
+var FAILS_ON_PRIMITIVES = require('../internals/fails')(function () { return !Object.getOwnPropertyNames(1); });
 
 // `Object.getOwnPropertyNames` method
 // https://tc39.github.io/ecma262/#sec-object.getownpropertynames


### PR DESCRIPTION
rollup treeshaking is removing the Object.getOwnPropertyNames
FAILS_ON_PRIMITIVES feature test.

This is related to these rollup issue
https://github.com/rollup/rollup/issues/1771
https://github.com/rollup/rollup/issues/2790

Related core-js issues
#494 
#513 