### PR TITLE
Fix broken getOwnPropertySymbols in Mobile Chrome 38 and 39

### DIFF
--- a/packages/core-js/internals/object-get-own-property-symbols-external.js
+++ b/packages/core-js/internals/object-get-own-property-symbols-external.js
@@ -1,6 +1,0 @@
-var toIndexedObject = require('../internals/to-indexed-object');
-var nativeGetOwnPropertySymbols = require('../internals/object-get-own-property-symbols').f;
-
-module.exports.f = function getOwnPropertySymbols(it) {
-  return nativeGetOwnPropertySymbols(toIndexedObject(it));
-};

--- a/packages/core-js/internals/object-get-own-property-symbols-external.js
+++ b/packages/core-js/internals/object-get-own-property-symbols-external.js
@@ -1,0 +1,6 @@
+var toIndexedObject = require('../internals/to-indexed-object');
+var nativeGetOwnPropertySymbols = require('../internals/object-get-own-property-symbols').f;
+
+module.exports.f = function getOwnPropertySymbols(it) {
+  return nativeGetOwnPropertySymbols(toIndexedObject(it));
+};

--- a/packages/core-js/modules/es.symbol.js
+++ b/packages/core-js/modules/es.symbol.js
@@ -23,6 +23,7 @@ var toPrimitive = require('../internals/to-primitive');
 var createPropertyDescriptor = require('../internals/create-property-descriptor');
 var nativeObjectCreate = require('../internals/object-create');
 var getOwnPropertyNamesExternal = require('../internals/object-get-own-property-names-external');
+var getOwnPropertySymbolsExternal = require('../internals/object-get-own-property-symbols-external');
 var getOwnPropertyDescriptorModule = require('../internals/object-get-own-property-descriptor');
 var definePropertyModule = require('../internals/object-define-property');
 var propertyIsEnumerableModule = require('../internals/object-property-is-enumerable');
@@ -36,6 +37,7 @@ var getInternalState = InternalStateModule.getterFor(SYMBOL);
 var nativeGetOwnPropertyDescriptor = getOwnPropertyDescriptorModule.f;
 var nativeDefineProperty = definePropertyModule.f;
 var nativeGetOwnPropertyNames = getOwnPropertyNamesExternal.f;
+var nativeGetOwnPropertySymbols = getOwnPropertySymbolsExternal.f;
 var $Symbol = global.Symbol;
 var JSON = global.JSON;
 var nativeJSONStringify = JSON && JSON.stringify;
@@ -238,6 +240,14 @@ $export({ target: 'Object', stat: true, forced: !NATIVE_SYMBOL }, {
   // `Object.getOwnPropertySymbols` method
   // https://tc39.github.io/ecma262/#sec-object.getownpropertysymbols
   getOwnPropertySymbols: $getOwnPropertySymbols
+});
+
+// Chome Mobile 38 and 39 getOwnPropertySymbols fails on primitives
+// https://bugs.chromium.org/p/v8/issues/detail?id=3443
+var FAILS_ON_PRIMITIVES = fails(function () { return !Object.getOwnPropertySymbols(1); });
+
+$export({ target: 'Object', stat: true, forced: FAILS_ON_PRIMITIVES }, {
+  getOwnPropertySymbols: nativeGetOwnPropertySymbols
 });
 
 // `JSON.stringify` method behavior with symbols

--- a/packages/core-js/modules/es.symbol.js
+++ b/packages/core-js/modules/es.symbol.js
@@ -18,12 +18,12 @@ var enumKeys = require('../internals/enum-keys');
 var isArray = require('../internals/is-array');
 var anObject = require('../internals/an-object');
 var isObject = require('../internals/is-object');
+var toObject = require('../internals/to-object');
 var toIndexedObject = require('../internals/to-indexed-object');
 var toPrimitive = require('../internals/to-primitive');
 var createPropertyDescriptor = require('../internals/create-property-descriptor');
 var nativeObjectCreate = require('../internals/object-create');
 var getOwnPropertyNamesExternal = require('../internals/object-get-own-property-names-external');
-var getOwnPropertySymbolsExternal = require('../internals/object-get-own-property-symbols-external');
 var getOwnPropertyDescriptorModule = require('../internals/object-get-own-property-descriptor');
 var definePropertyModule = require('../internals/object-define-property');
 var propertyIsEnumerableModule = require('../internals/object-property-is-enumerable');
@@ -37,7 +37,7 @@ var getInternalState = InternalStateModule.getterFor(SYMBOL);
 var nativeGetOwnPropertyDescriptor = getOwnPropertyDescriptorModule.f;
 var nativeDefineProperty = definePropertyModule.f;
 var nativeGetOwnPropertyNames = getOwnPropertyNamesExternal.f;
-var nativeGetOwnPropertySymbols = getOwnPropertySymbolsExternal.f;
+var nativeGetOwnPropertySymbolsModule = require('../internals/object-get-own-property-symbols');
 var $Symbol = global.Symbol;
 var JSON = global.JSON;
 var nativeJSONStringify = JSON && JSON.stringify;
@@ -174,7 +174,7 @@ if (!NATIVE_SYMBOL) {
   definePropertyModule.f = $defineProperty;
   getOwnPropertyDescriptorModule.f = $getOwnPropertyDescriptor;
   require('../internals/object-get-own-property-names').f = getOwnPropertyNamesExternal.f = $getOwnPropertyNames;
-  require('../internals/object-get-own-property-symbols').f = $getOwnPropertySymbols;
+  nativeGetOwnPropertySymbolsModule.f = $getOwnPropertySymbols;
 
   if (DESCRIPTORS) {
     // https://github.com/tc39/proposal-Symbol-description
@@ -247,7 +247,9 @@ $export({ target: 'Object', stat: true, forced: !NATIVE_SYMBOL }, {
 var FAILS_ON_PRIMITIVES = fails(function () { return !Object.getOwnPropertySymbols(1); });
 
 $export({ target: 'Object', stat: true, forced: FAILS_ON_PRIMITIVES }, {
-  getOwnPropertySymbols: nativeGetOwnPropertySymbols
+  getOwnPropertySymbols: function getOwnPropertySymbols(it) {
+    return nativeGetOwnPropertySymbolsModule.f(toObject(it));
+  }
 });
 
 // `JSON.stringify` method behavior with symbols

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -158,6 +158,7 @@ function createStringTrimMethodTest(METHOD_NAME) {
 GLOBAL.tests = {
   'es.symbol': [SYMBOLS_SUPPORT, function () {
     return Object.getOwnPropertySymbols
+      && Object.getOwnPropertySymbols('qwe')
       && Symbol['for']
       && Symbol.keyFor
       && JSON.stringify([Symbol()]) == '[null]'

--- a/tests/pure/es.symbol.js
+++ b/tests/pure/es.symbol.js
@@ -85,6 +85,10 @@ QUnit.test('Object.getOwnPropertySymbols', assert => {
   assert.deepEqual(getOwnPropertyNames(object).sort(), ['a', 'd', 's']);
   assert.strictEqual(getOwnPropertySymbols(object).length, 1);
   assert.strictEqual(getOwnPropertySymbols(Object.prototype).length, 0);
+  const primitives = [42, 'foo', false];
+  for (const value of primitives) {
+    assert.notThrows(() => getOwnPropertySymbols(value), `accept ${ typeof value }`);
+  }
 });
 
 if (JSON) {

--- a/tests/tests/es.symbol.js
+++ b/tests/tests/es.symbol.js
@@ -103,6 +103,10 @@ QUnit.test('Object.getOwnPropertySymbols', assert => {
   assert.deepEqual(getOwnPropertyNames(object).sort(), ['a', 'd', 's']);
   assert.strictEqual(getOwnPropertySymbols(object).length, 1);
   assert.strictEqual(getOwnPropertySymbols(Object.prototype).length, 0);
+  const primitives = [42, 'foo', false];
+  for (const value of primitives) {
+    assert.notThrows(() => getOwnPropertySymbols(value), `accept ${ typeof value }`);
+  }
 });
 
 if (JSON) {


### PR DESCRIPTION
This is a workaround for this chrome issue
https://bugs.chromium.org/p/v8/issues/detail?id=3443

Without this fix, the object spread operator is broken for these
versions of chrome when transpiling and shimming with babel and
core-js@3.
See https://github.com/babel/babel/issues/8721