### PR TITLE
[core-js-compat] Filter available modules without using an intermediate set

### DIFF
--- a/packages/core-js-compat/index.js
+++ b/packages/core-js-compat/index.js
@@ -3,7 +3,6 @@ const { coerce, lt, lte } = require('semver');
 const browserslist = require('browserslist');
 const data = require('./data');
 const getModulesListForTargetVersion = require('./get-modules-list-for-target-version');
-const intersection = require('core-js-pure/features/set/intersection');
 const has = Function.call.bind({}.hasOwnProperty);
 
 const mapping = new Map([
@@ -86,7 +85,8 @@ function compat({ targets, filter, version }) {
   else if (typeof filter == 'string') modules = modules.filter(it => it.startsWith(filter));
 
   if (version) {
-    modules = [...intersection(new Set(getModulesListForTargetVersion(version)), new Set(modules))];
+    const availableModules = new Set(getModulesListForTargetVersion(version));
+    modules = modules.filter(name => availableModules.has(name));
   }
 
   modules.forEach(key => {

--- a/packages/core-js-compat/package.json
+++ b/packages/core-js-compat/package.json
@@ -12,7 +12,6 @@
     "semver": "^6.1.3"
   },
   "devDependencies": {
-    "core-js-pure": "3.1.4",
     "detective": "^5.2.0",
     "electron-to-chromium": "^1.3.180",
     "glob": "^7.1.4"

--- a/packages/core-js-compat/package.json
+++ b/packages/core-js-compat/package.json
@@ -9,10 +9,10 @@
   "main": "index.js",
   "dependencies": {
     "browserslist": "^4.6.3",
-    "core-js-pure": "3.1.4",
     "semver": "^6.1.3"
   },
   "devDependencies": {
+    "core-js-pure": "3.1.4",
     "detective": "^5.2.0",
     "electron-to-chromium": "^1.3.180",
     "glob": "^7.1.4"

--- a/packages/core-js-compat/src/build-entries.js
+++ b/packages/core-js-compat/src/build-entries.js
@@ -3,9 +3,8 @@ const { readFileSync, writeFileSync } = require('fs');
 const { dirname, resolve } = require('path');
 const detective = require('detective');
 const { sync: glob } = require('glob');
-const intersection = require('core-js-pure/features/set/intersection');
 const data = require('./data');
-const order = new Set(Object.keys(data));
+const order = Object.keys(data);
 
 function getModulesForEntryPoint(entry) {
   const match = entry.match(/\/modules\/([^/]+)$/);
@@ -19,7 +18,7 @@ function getModulesForEntryPoint(entry) {
     const relative = resolve(dir, dependency);
     result.push(...getModulesForEntryPoint(relative));
   }
-  return [...intersection(new Set(result), order)];
+  return result.sort((a, b) => order.indexOf(a) > order.indexOf(b) ? 1 : -1);
 }
 
 const entries = {};

--- a/packages/core-js-compat/src/build-entries.js
+++ b/packages/core-js-compat/src/build-entries.js
@@ -18,7 +18,8 @@ function getModulesForEntryPoint(entry) {
     const relative = resolve(dir, dependency);
     result.push(...getModulesForEntryPoint(relative));
   }
-  return result.sort((a, b) => order.indexOf(a) > order.indexOf(b) ? 1 : -1);
+  const resultSet = new Set(result);
+  return order.filter(it => resultSet.has(it));
 }
 
 const entries = {};


### PR DESCRIPTION
Ref: https://github.com/babel/babel/pull/10158#issuecomment-508285566