### PR TITLE
update core-js-compat for Firefox 67

### DIFF
--- a/packages/core-js-compat/src/data.js
+++ b/packages/core-js-compat/src/data.js
@@ -838,6 +838,7 @@ const data = {
   },
   'es.string.match-all': {
     chrome: '73',
+    firefox: '67',
   },
   'es.string.pad-end': {
     edge: '15',


### PR DESCRIPTION
Looks like `es.string.match-all` is supported in Firefox 67. MDN also confirms this: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll#Browser_compatibility

Thanks!