### PR TITLE
Check for backwards slashes in module regex

### DIFF
--- a/packages/core-js-compat/src/build-entries.js
+++ b/packages/core-js-compat/src/build-entries.js
@@ -7,7 +7,7 @@ const data = require('./data');
 const order = Object.keys(data);
 
 function getModulesForEntryPoint(entry) {
-  const match = entry.match(/\/modules\/([^/]+)$/);
+  const match = entry.match(/[/\\]modules[/\\]([^/\\]+)$/);
   if (match) return [match[1]];
   const name = require.resolve(entry);
   const result = [];


### PR DESCRIPTION
Check for both backwards and forwards slashes so the regex matches paths found by windows as well. Fixes #605