### PR TITLE
Avoid conflicts between Promise from core-js and Promise from zone.js

### DIFF
--- a/packages/core-js/modules/es.promise.js
+++ b/packages/core-js/modules/es.promise.js
@@ -59,6 +59,7 @@ var FORCED = isForced(PROMISE, function () {
   // unhandled rejections tracking support, NodeJS Promise without it fails @@species test
   return !((IS_NODE || typeof PromiseRejectionEvent == 'function')
     && (!IS_PURE || promise['finally'])
+    && typeof promise.constructor === 'object'
     && promise.then(empty) instanceof FakePromise
     // v8 6.6 (Node 10 and Chrome 66) have a bug with resolving custom thenables
     // https://bugs.chromium.org/p/chromium/issues/detail?id=830565


### PR DESCRIPTION
When loaded, zone.js will patch global Promise.
When loaded, core-js will run a detection routine to determine if it needs to patch global Promise.

If core-js is loaded before zone.js, everything works fine.
If core-js is loaded after zone.js and the order of these events cannot be changed, core-js will fail to detect a patched global Promise, causing its detection code to patch it again.

This pull request aims to improve the detection routine to avoid conflicts between core-js Promise polyfill and zone.js Promise polyfill.