### PR TITLE
remove author's job search ad to conform with the new NPM policy

### DIFF
--- a/packages/core-js/scripts/postinstall.js
+++ b/packages/core-js/scripts/postinstall.js
@@ -20,5 +20,4 @@ if (!ADBLOCK && !CI && !DISABLE_OPENCOLLECTIVE && !SILENT) {
   log('\u001B[96mThe project needs your help! Please consider supporting of core-js on Open Collective or Patreon: \u001B[0m');
   log('\u001B[96m>\u001B[94m https://opencollective.com/core-js \u001B[0m');
   log('\u001B[96m>\u001B[94m https://www.patreon.com/zloirock \u001B[0m\n');
-  log('\u001B[96mAlso, the author of core-js (\u001B[94m https://github.com/zloirock \u001B[96m) is looking for a good job -)\u001B[0m\n');
 }


### PR DESCRIPTION
While I don't really agree with the new NPM policy as reported here: https://www.zdnet.com/article/npm-bans-terminal-ads/
I do think it could give grounds for removal/ban of this package. If this were to happen, we'd get another left-pad debacle.
So maybe let's remove this just to be on the safe side with NPM shall we?