### PR TITLE
`String#{ matchAll, replaceAll }` throws a error on non-global regex argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ##### Unreleased
+- **`String#{ matchAll, replaceAll }` throws an error on non-global regex argument per [this PR](https://github.com/tc39/proposal-string-replaceall/pull/24) and the decision from TC39 meetings. It's a breaking change, but because it's a breaking change in the ES spec, it's added at the minor release**
 - Added [iterator helpers stage 2 proposal](https://github.com/tc39/proposal-iterator-helpers):
   - `Iterator`
     - `Iterator.from`

--- a/packages/core-js-compat/src/data.js
+++ b/packages/core-js-compat/src/data.js
@@ -848,9 +848,10 @@ const data = {
     safari: '10.0',
   },
   'es.string.match-all': {
-    chrome: '73',
-    firefox: '67',
-    safari: '13',
+    // Early implementations does not throw an error on non-global regex
+    // chrome: '73',
+    // firefox: '67',
+    // safari: '13',
   },
   'es.string.pad-end': {
     edge: '15',

--- a/packages/core-js/modules/esnext.symbol.replace-all.js
+++ b/packages/core-js/modules/esnext.symbol.replace-all.js
@@ -1,5 +1,4 @@
+// TODO: remove from `core-js@4`
 var defineWellKnownSymbol = require('../internals/define-well-known-symbol');
 
-// `Symbol.replaceAll` well-known symbol
-// https://tc39.github.io/proposal-string-replaceall/
 defineWellKnownSymbol('replaceAll');

--- a/tests/commonjs.js
+++ b/tests/commonjs.js
@@ -221,7 +221,7 @@ for (const _PATH of ['../packages/core-js-pure', '../packages/core-js']) {
   ok(load('features/string/trim-end')(' a ') === ' a');
   ok(load('features/string/trim-left')(' a ') === 'a ');
   ok(load('features/string/trim-right')(' a ') === ' a');
-  ok('next' in load('features/string/match-all')('a', /./));
+  ok('next' in load('features/string/match-all')('a', /./g));
   ok(typeof load('features/string/replace-all') === 'function');
   ok('next' in load('features/string/iterator')('qwe'));
   ok(load('features/string/virtual/code-point-at').call('a', 0) === 97);
@@ -250,7 +250,7 @@ for (const _PATH of ['../packages/core-js-pure', '../packages/core-js']) {
   ok(load('features/string/virtual/trim-end').call(' a ') === ' a');
   ok(load('features/string/virtual/trim-left').call(' a ') === 'a ');
   ok(load('features/string/virtual/trim-right').call(' a ') === ' a');
-  ok('next' in load('features/string/virtual/match-all').call('a', /./));
+  ok('next' in load('features/string/virtual/match-all').call('a', /./g));
   ok(typeof load('features/string/virtual/replace-all') === 'function');
   ok(load('features/string/virtual').at.call('a', 0) === 'a');
   ok('next' in load('features/string/virtual/iterator').call('qwe'));
@@ -559,7 +559,7 @@ for (const _PATH of ['../packages/core-js-pure', '../packages/core-js']) {
   ok(load('stable/string/ends-with')('qwe', 'we'));
   ok(load('stable/string/includes')('qwe', 'w'));
   ok(load('stable/string/repeat')('q', 3) === 'qqq');
-  ok('next' in load('stable/string/match-all')('a', /./));
+  ok('next' in load('stable/string/match-all')('a', /./g));
   ok(load('stable/string/starts-with')('qwe', 'qw'));
   ok(typeof load('stable/string/anchor') === 'function');
   ok(typeof load('stable/string/big') === 'function');
@@ -1626,7 +1626,7 @@ load('features/typed-array/to-string');
 load('features/typed-array/values');
 ok(typeof load('features/typed-array').Uint32Array === 'function');
 ok(typeof load('es/string/match') === 'function');
-ok('next' in load('es/string/match-all')('a', /./));
+ok('next' in load('es/string/match-all')('a', /./g));
 ok(typeof load('es/string/replace') === 'function');
 ok(typeof load('es/string/search') === 'function');
 ok(load('es/string/split')('a s d', ' ').length === 3);

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -766,7 +766,11 @@ GLOBAL.tests = {
     return ''.match(O) == 7 && execCalled;
   },
   'es.string.match-all': function () {
-    return String.prototype.matchAll;
+    try {
+      'a'.matchAll(/./);
+    } catch (error) {
+      return 'a'.matchAll(/./g);
+    }
   },
   'es.string.pad-end': function () {
     return String.prototype.padEnd && !WEBKIT_STRING_PAD_BUG;

--- a/tests/pure/es.string.match-all.js
+++ b/tests/pure/es.string.match-all.js
@@ -69,20 +69,7 @@ QUnit.test('String#matchAll', assert => {
     value: undefined,
     done: true,
   });
-  iterator = matchAll('1111a2b3cccc', /(\d)(\D)/);
-  assert.isIterator(iterator);
-  assert.isIterable(iterator);
-  assert.deepEqual(iterator.next(), {
-    value: assign(['1a', '1', 'a'], {
-      input: '1111a2b3cccc',
-      index: 3,
-    }),
-    done: false,
-  });
-  assert.deepEqual(iterator.next(), {
-    value: undefined,
-    done: true,
-  });
+  assert.throws(() => matchAll('1111a2b3cccc', /(\d)(\D)/), TypeError);
   iterator = matchAll('1111a2b3cccc', '(\\d)(\\D)');
   assert.isIterator(iterator);
   assert.isIterable(iterator);

--- a/tests/pure/esnext.string.replace-all.js
+++ b/tests/pure/esnext.string.replace-all.js
@@ -16,7 +16,7 @@ QUnit.test('String#replaceAll', assert => {
     return 'c';
   }), 'aca');
   const searcher = {
-    [Symbol.replaceAll](O, replaceValue) {
+    [Symbol.replace](O, replaceValue) {
       assert.same(this, searcher, '`this` is `searcher`');
       assert.same(String(O), 'aba', '`O` is `aba`');
       assert.same(String(replaceValue), 'c', '`replaceValue` is `c`');
@@ -29,7 +29,7 @@ QUnit.test('String#replaceAll', assert => {
     assert.throws(() => replaceAll(null, 'a', 'b'), TypeError);
     assert.throws(() => replaceAll(undefined, 'a', 'b'), TypeError);
   }
-  assert.same(replaceAll('b.b.b.b.b', /\./, 'a'), 'babababab');
+  assert.throws(() => replaceAll('b.b.b.b.b', /\./, 'a'), TypeError);
   assert.same(replaceAll('b.b.b.b.b', /\./g, 'a'), 'babababab');
   const object = {};
   assert.same(replaceAll('[object Object]', object, 'a'), 'a');

--- a/tests/tests/es.string.match-all.js
+++ b/tests/tests/es.string.match-all.js
@@ -69,20 +69,7 @@ QUnit.test('String#matchAll', assert => {
     value: undefined,
     done: true,
   });
-  iterator = '1111a2b3cccc'.matchAll(/(\d)(\D)/);
-  assert.isIterator(iterator);
-  assert.isIterable(iterator);
-  assert.deepEqual(iterator.next(), {
-    value: assign(['1a', '1', 'a'], {
-      input: '1111a2b3cccc',
-      index: 3,
-    }),
-    done: false,
-  });
-  assert.deepEqual(iterator.next(), {
-    value: undefined,
-    done: true,
-  });
+  assert.throws(() => '1111a2b3cccc'.matchAll(/(\d)(\D)/), TypeError);
   iterator = '1111a2b3cccc'.matchAll('(\\d)(\\D)');
   assert.isIterator(iterator);
   assert.isIterable(iterator);

--- a/tests/tests/esnext.string.replace-all.js
+++ b/tests/tests/esnext.string.replace-all.js
@@ -18,7 +18,7 @@ QUnit.test('String#replaceAll', assert => {
     return 'c';
   }), 'aca');
   const searcher = {
-    [Symbol.replaceAll](O, replaceValue) {
+    [Symbol.replace](O, replaceValue) {
       assert.same(this, searcher, '`this` is `searcher`');
       assert.same(String(O), 'aba', '`O` is `aba`');
       assert.same(String(replaceValue), 'c', '`replaceValue` is `c`');
@@ -31,7 +31,7 @@ QUnit.test('String#replaceAll', assert => {
     assert.throws(() => replaceAll.call(null, 'a', 'b'), TypeError);
     assert.throws(() => replaceAll.call(undefined, 'a', 'b'), TypeError);
   }
-  assert.same('b.b.b.b.b'.replaceAll(/\./, 'a'), 'babababab');
+  assert.throws(() => 'b.b.b.b.b'.replaceAll(/\./, 'a'), TypeError);
   assert.same('b.b.b.b.b'.replaceAll(/\./g, 'a'), 'babababab');
   const object = {};
   assert.same('[object Object]'.replaceAll(object, 'a'), 'a');


### PR DESCRIPTION
per https://github.com/tc39/proposal-string-replaceall/pull/24 and the decision from TC39 meetings