### PR TITLE
Fix an error when using URLSearchParams with fetch

### DIFF
--- a/packages/core-js/modules/web.url-search-params.js
+++ b/packages/core-js/modules/web.url-search-params.js
@@ -325,7 +325,7 @@ if (!USE_NATIVE_URL && typeof $fetch == 'function' && typeof Headers == 'functio
         if (isObject(init)) {
           body = init.body;
           if (classof(body) === URL_SEARCH_PARAMS) {
-            headers = new Headers(init.headers);
+            headers = init.headers ? new Headers(init.headers) : new Headers();
             if (!headers.has('content-type')) {
               headers.set('content-type', 'application/x-www-form-urlencoded;charset=UTF-8');
             }


### PR DESCRIPTION
Fix the following error occurred in WeChat Windows client (based on Chrome 53 from UA), when passing an `URLSearchParams` as body and not passing headers.

message: "Failed to construct 'Headers': No matching constructor signature."
stack: TypeError: Failed to construct 'Headers': No matching constructor signature.
 at TypeError (native)
 at fetch (webpack-internal:///./node_modules/core-js/modules/web.url-search-params.js:328:23)
 at _callee$ (webpack-internal:///./src/api/internal.ts:180:20)
 at tryCatch (webpack-internal:///./node_modules/regenerator-runtime/runtime.js:45:40)
...