### PR TITLE
fix: post installs fails with powershell

### DIFF
--- a/packages/core-js-bundle/package.json
+++ b/packages/core-js-bundle/package.json
@@ -48,6 +48,6 @@
     "shim"
   ],
   "scripts": {
-    "postinstall": "node postinstall || echo \"ignore\""
+    "postinstall": "node -e \"try { require('./scripts/postinstall'); } catch (e) { }; process.exit(0) \""
   }
 }

--- a/packages/core-js-pure/package.json
+++ b/packages/core-js-pure/package.json
@@ -48,6 +48,6 @@
     "shim"
   ],
   "scripts": {
-    "postinstall": "node postinstall || echo \"ignore\""
+    "postinstall": "node -e \"try { require('./scripts/postinstall'); } catch (e) { }; process.exit(0) \""
   }
 }

--- a/packages/core-js/package.json
+++ b/packages/core-js/package.json
@@ -48,6 +48,6 @@
     "shim"
   ],
   "scripts": {
-    "postinstall": "node postinstall || echo \"ignore\""
+    "postinstall": "node -e \"try { require('./scripts/postinstall'); } catch (e) { }; process.exit(0) \""
   }
 }


### PR DESCRIPTION
with npm config set script-shell powershell.exe the postinstall hook
failes with the error

```
> node postinstall || echo "ignore"

At line:1 char:18
+ node postinstall || echo "ignore"
+                  ~~
The token '||' is not a valid statement separator in this version.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : InvalidEndOfLine
```