### PR TITLE
Remove copyright from executable code

### DIFF
--- a/packages/core-js/internals/shared.js
+++ b/packages/core-js/internals/shared.js
@@ -6,5 +6,4 @@ var store = require('../internals/shared-store');
 })('versions', []).push({
   version: '3.4.0',
   mode: IS_PURE ? 'pure' : 'global',
-  copyright: '© 2019 Denis Pushkarev (zloirock.ru)'
 });


### PR DESCRIPTION
This winds up in the minified distribution everywhere this library is used instead of the usual inclusion on a page with a list of the open source software used (i.e. licenses page). It's a minor thing, but multiplied by millions and millions of instances of the notice across likely billions of requests.