### PR TITLE
Check if startsWith is configurable

### DIFF
--- a/packages/core-js/modules/es.string.starts-with.js
+++ b/packages/core-js/modules/es.string.starts-with.js
@@ -8,16 +8,18 @@ var correctIsRegExpLogic = require('../internals/correct-is-regexp-logic');
 var nativeStartsWith = ''.startsWith;
 var min = Math.min;
 
-// `String.prototype.startsWith` method
-// https://tc39.github.io/ecma262/#sec-string.prototype.startswith
-$({ target: 'String', proto: true, forced: !correctIsRegExpLogic('startsWith') }, {
-  startsWith: function startsWith(searchString /* , position = 0 */) {
-    var that = String(requireObjectCoercible(this));
-    notARegExp(searchString);
-    var index = toLength(min(arguments.length > 1 ? arguments[1] : undefined, that.length));
-    var search = String(searchString);
-    return nativeStartsWith
-      ? nativeStartsWith.call(that, search, index)
-      : that.slice(index, index + search.length) === search;
-  }
-});
+if(Object.getOwnPropertyDescriptor(String.prototype, "startsWith").configurable) {
+  // `String.prototype.startsWith` method
+  // https://tc39.github.io/ecma262/#sec-string.prototype.startswith
+  $({ target: 'String', proto: true, forced: !correctIsRegExpLogic('startsWith') }, {
+    startsWith: function startsWith(searchString /* , position = 0 */) {
+      var that = String(requireObjectCoercible(this));
+      notARegExp(searchString);
+      var index = toLength(min(arguments.length > 1 ? arguments[1] : undefined, that.length));
+      var search = String(searchString);
+      return nativeStartsWith
+        ? nativeStartsWith.call(that, search, index)
+        : that.slice(index, index + search.length) === search;
+    }
+  });
+}


### PR DESCRIPTION
String.startsWith polyfill will throw an exception if the existing property is not configurable.  Other polyfills will likely throw an exception under the same scenario.  Perhaps an update like this belongs farther up the chain.

This still needs to be tested.  Wanted to start the PR process to open the discussion