### PR TITLE
Sticky RegExp 'y' and RegExp#test delegation

### DIFF
--- a/packages/core-js-compat/src/data.js
+++ b/packages/core-js-compat/src/data.js
@@ -821,6 +821,11 @@ const data = {
     firefox: '3',
     safari: '10.0',
   },
+  'es.regexp.test': {
+    chrome: '51',
+    firefox: '46',
+    safari: '10.0',
+  },
   'es.regexp.to-string': {
     chrome: '50',
     firefox: '46',

--- a/packages/core-js-compat/src/data.js
+++ b/packages/core-js-compat/src/data.js
@@ -815,6 +815,12 @@ const data = {
     firefox: '37',
     safari: '9.0',
   },
+  'es.regexp.sticky': {
+    chrome: '49',
+    edge: '13',
+    firefox: '3',
+    safari: '10.0',
+  },
   'es.regexp.to-string': {
     chrome: '50',
     firefox: '46',

--- a/packages/core-js-compat/src/data.js
+++ b/packages/core-js-compat/src/data.js
@@ -806,9 +806,9 @@ const data = {
   },
   'es.regexp.exec': {
     chrome: '26',
-    firefox: '4',
-    ie: '9',
-    safari: '8.0',
+    firefox: '44',
+    edge: '13',
+    safari: '10.0',
   },
   'es.regexp.flags': {
     chrome: '49',

--- a/packages/core-js/es/index.js
+++ b/packages/core-js/es/index.js
@@ -106,6 +106,7 @@ require('../modules/es.regexp.constructor');
 require('../modules/es.regexp.exec');
 require('../modules/es.regexp.flags');
 require('../modules/es.regexp.sticky');
+require('../modules/es.regexp.test');
 require('../modules/es.regexp.to-string');
 require('../modules/es.parse-int');
 require('../modules/es.parse-float');

--- a/packages/core-js/es/index.js
+++ b/packages/core-js/es/index.js
@@ -105,6 +105,7 @@ require('../modules/es.string.sup');
 require('../modules/es.regexp.constructor');
 require('../modules/es.regexp.exec');
 require('../modules/es.regexp.flags');
+require('../modules/es.regexp.sticky');
 require('../modules/es.regexp.to-string');
 require('../modules/es.parse-int');
 require('../modules/es.parse-float');

--- a/packages/core-js/es/regexp/index.js
+++ b/packages/core-js/es/regexp/index.js
@@ -3,6 +3,7 @@ require('../../modules/es.regexp.to-string');
 require('../../modules/es.regexp.exec');
 require('../../modules/es.regexp.flags');
 require('../../modules/es.regexp.sticky');
+require('../../modules/es.regexp.test');
 require('../../modules/es.string.match');
 require('../../modules/es.string.replace');
 require('../../modules/es.string.search');

--- a/packages/core-js/es/regexp/index.js
+++ b/packages/core-js/es/regexp/index.js
@@ -2,6 +2,7 @@ require('../../modules/es.regexp.constructor');
 require('../../modules/es.regexp.to-string');
 require('../../modules/es.regexp.exec');
 require('../../modules/es.regexp.flags');
+require('../../modules/es.regexp.sticky');
 require('../../modules/es.string.match');
 require('../../modules/es.string.replace');
 require('../../modules/es.string.search');

--- a/packages/core-js/es/regexp/sticky.js
+++ b/packages/core-js/es/regexp/sticky.js
@@ -1,0 +1,5 @@
+require('../../modules/es.regexp.sticky');
+
+module.exports = function (it) {
+  return it.sticky;
+};

--- a/packages/core-js/internals/fix-regexp-well-known-symbol-logic.js
+++ b/packages/core-js/internals/fix-regexp-well-known-symbol-logic.js
@@ -3,6 +3,7 @@ var redefine = require('../internals/redefine');
 var fails = require('../internals/fails');
 var wellKnownSymbol = require('../internals/well-known-symbol');
 var regexpExec = require('../internals/regexp-exec');
+var createNonEnumerableProperty = require('../internals/create-non-enumerable-property');
 
 var SPECIES = wellKnownSymbol('species');
 
@@ -35,7 +36,7 @@ var SPLIT_WORKS_WITH_OVERWRITTEN_EXEC = !fails(function () {
   return result.length !== 2 || result[0] !== 'a' || result[1] !== 'b';
 });
 
-module.exports = function (KEY, length, exec) {
+module.exports = function (KEY, length, exec, sham) {
   var SYMBOL = wellKnownSymbol(KEY);
 
   var DELEGATES_TO_SYMBOL = !fails(function () {
@@ -101,4 +102,6 @@ module.exports = function (KEY, length, exec) {
       : function (string) { return regexMethod.call(string, this); }
     );
   }
+
+  if (sham) createNonEnumerableProperty(RegExp.prototype[SYMBOL], 'sham', true);
 };

--- a/packages/core-js/internals/regexp-exec.js
+++ b/packages/core-js/internals/regexp-exec.js
@@ -1,5 +1,6 @@
 'use strict';
 var regexpFlags = require('./regexp-flags');
+var stickyHelpers = require('./regexp-sticky-helpers');
 
 var nativeExec = RegExp.prototype.exec;
 // This always refers to the native implementation, because the
@@ -17,24 +18,42 @@ var UPDATES_LAST_INDEX_WRONG = (function () {
   return re1.lastIndex !== 0 || re2.lastIndex !== 0;
 })();
 
+var UNSUPPORTED_Y = stickyHelpers.UNSUPPORTED_Y || stickyHelpers.BROKEN_CARET;
+
 // nonparticipating capturing group, copied from es5-shim's String#split patch.
 var NPCG_INCLUDED = /()??/.exec('')[1] !== undefined;
 
-var PATCH = UPDATES_LAST_INDEX_WRONG || NPCG_INCLUDED;
+var PATCH = UPDATES_LAST_INDEX_WRONG || NPCG_INCLUDED || UNSUPPORTED_Y;
 
 if (PATCH) {
   patchedExec = function exec(str) {
     var re = this;
     var lastIndex, reCopy, match, i;
+    var sticky = UNSUPPORTED_Y && re.sticky;
+
+    if (sticky) {
+      var flags = (re.ignoreCase ? 'i' : '') +
+                  (re.multiline ? 'm' : '') +
+                  (re.unicode ? 'u' : '') +
+                  'g';
+
+      // ^(? + rx + ) is needed, in combination with some str slicing, to
+      // simulate the 'y' flag.
+      reCopy = new RegExp('^(?:' + re.source + ')', flags);
+      str = String(str).slice(re.lastIndex);
+    }
 
     if (NPCG_INCLUDED) {
       reCopy = new RegExp('^' + re.source + '$(?!\\s)', regexpFlags.call(re));
     }
     if (UPDATES_LAST_INDEX_WRONG) lastIndex = re.lastIndex;
 
-    match = nativeExec.call(re, str);
+    match = nativeExec.call(sticky ? reCopy : re, str);
 
-    if (UPDATES_LAST_INDEX_WRONG && match) {
+    if (sticky) {
+      if (match) re.lastIndex += match[0].length;
+      else re.lastIndex = 0;
+    } else if (UPDATES_LAST_INDEX_WRONG && match) {
       re.lastIndex = re.global ? match.index + match[0].length : lastIndex;
     }
     if (NPCG_INCLUDED && match && match.length > 1) {

--- a/packages/core-js/internals/regexp-exec.js
+++ b/packages/core-js/internals/regexp-exec.js
@@ -42,6 +42,7 @@ if (PATCH) {
       }
 
       strCopy = String(str).slice(re.lastIndex);
+      // Support anchored sticky behavior.
       if (re.lastIndex > 0 && (!re.multiline || re.multiline && str[re.lastIndex - 1] !== '\n')) {
         source = '(?: ' + source + ')';
         strCopy = ' ' + strCopy;
@@ -66,7 +67,6 @@ if (PATCH) {
         match.index = re.lastIndex;
         re.lastIndex += match[0].length;
       } else re.lastIndex = 0;
-      // console.log('DEBUG:', reCopy.source, reCopy.lastIndex, re.lastIndex, flags, str, match);
     } else if (UPDATES_LAST_INDEX_WRONG && match) {
       re.lastIndex = re.global ? match.index + match[0].length : lastIndex;
     }

--- a/packages/core-js/internals/regexp-sticky-helpers.js
+++ b/packages/core-js/internals/regexp-sticky-helpers.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var fails = require('./fails');
+var speciesConstructor = require('../internals/species-constructor');
+
+// babel-minify transpiles RegExp('a', 'y') -> /a/y and it causes SyntaxError,
+// so we use an intermediate function.
+function RE(s, f) {
+  return RegExp(s, f);
+}
+
+exports.UNSUPPORTED_Y = fails(function () {
+  // babel-minify transpiles RegExp('a', 'y') -> /a/y and it causes SyntaxError
+  var re = RE('a', 'y');
+  re.lastIndex = 2;
+  return re.exec('abcd') != null;
+});
+
+exports.BROKEN_CARET = fails(function () {
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=773687
+  var re = RE('^r', 'gy');
+  re.lastIndex = 2;
+  return re.exec('str') != null;
+});
+
+exports.createStickyRegExp = function (re, otherFlags) {
+  var C = speciesConstructor(re, RegExp);
+
+  if (C !== RegExp) return new C(re, otherFlags + 'y');
+
+  // y is either supported or polyfilled
+  if (!exports.UNSUPPORTED_Y || RegExp.sham) {
+    return new RegExp(re, otherFlags + 'y');
+  }
+
+  // If y hasn't been polyfilled and it isn't supported, assigning
+  // to .sticky won't throw.
+  // This usually happens in engines where descriptors aren't supported.
+  var fakeRe = new RegExp(re, otherFlags);
+  fakeRe.sticky = true;
+  return fakeRe;
+};

--- a/packages/core-js/internals/regexp-sticky-helpers.js
+++ b/packages/core-js/internals/regexp-sticky-helpers.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var fails = require('./fails');
-var speciesConstructor = require('../internals/species-constructor');
 
 // babel-minify transpiles RegExp('a', 'y') -> /a/y and it causes SyntaxError,
 // so we use an intermediate function.
@@ -22,21 +21,3 @@ exports.BROKEN_CARET = fails(function () {
   re.lastIndex = 2;
   return re.exec('str') != null;
 });
-
-exports.createStickyRegExp = function (re, otherFlags) {
-  var C = speciesConstructor(re, RegExp);
-
-  if (C !== RegExp) return new C(re, otherFlags + 'y');
-
-  // y is either supported or polyfilled
-  if (!exports.UNSUPPORTED_Y || RegExp.sham) {
-    return new RegExp(re, otherFlags + 'y');
-  }
-
-  // If y hasn't been polyfilled and it isn't supported, assigning
-  // to .sticky won't throw.
-  // This usually happens in engines where descriptors aren't supported.
-  var fakeRe = new RegExp(re, otherFlags);
-  fakeRe.sticky = true;
-  return fakeRe;
-};

--- a/packages/core-js/modules/es.regexp.constructor.js
+++ b/packages/core-js/modules/es.regexp.constructor.js
@@ -1,5 +1,4 @@
 var DESCRIPTORS = require('../internals/descriptors');
-var createNonEnumerableProperty = require('../internals/create-non-enumerable-property');
 var global = require('../internals/global');
 var isForced = require('../internals/is-forced');
 var inheritIfRequired = require('../internals/inherit-if-required');
@@ -78,8 +77,6 @@ if (FORCED) {
   RegExpPrototype.constructor = RegExpWrapper;
   RegExpWrapper.prototype = RegExpPrototype;
   redefine(global, 'RegExp', RegExpWrapper);
-
-  if (UNSUPPORTED_Y) createNonEnumerableProperty(RegExpWrapper, 'sham', true);
 }
 
 // https://tc39.github.io/ecma262/#sec-get-regexp-@@species

--- a/packages/core-js/modules/es.regexp.constructor.js
+++ b/packages/core-js/modules/es.regexp.constructor.js
@@ -1,4 +1,5 @@
 var DESCRIPTORS = require('../internals/descriptors');
+var createNonEnumerableProperty = require('../internals/create-non-enumerable-property');
 var global = require('../internals/global');
 var isForced = require('../internals/is-forced');
 var inheritIfRequired = require('../internals/inherit-if-required');
@@ -6,8 +7,10 @@ var defineProperty = require('../internals/object-define-property').f;
 var getOwnPropertyNames = require('../internals/object-get-own-property-names').f;
 var isRegExp = require('../internals/is-regexp');
 var getFlags = require('../internals/regexp-flags');
+var stickyHelpers = require('../internals/regexp-sticky-helpers');
 var redefine = require('../internals/redefine');
 var fails = require('../internals/fails');
+var setInternalState = require('../internals/internal-state').set;
 var setSpecies = require('../internals/set-species');
 var wellKnownSymbol = require('../internals/well-known-symbol');
 
@@ -20,7 +23,9 @@ var re2 = /a/g;
 // "new" should create a new object, old webkit bug
 var CORRECT_NEW = new NativeRegExp(re1) !== re1;
 
-var FORCED = DESCRIPTORS && isForced('RegExp', (!CORRECT_NEW || fails(function () {
+var UNSUPPORTED_Y = stickyHelpers.UNSUPPORTED_Y;
+
+var FORCED = DESCRIPTORS && isForced('RegExp', (!CORRECT_NEW || UNSUPPORTED_Y || fails(function () {
   re2[MATCH] = false;
   // RegExp constructor can alter flags and IsRegExp works correct with @@match
   return NativeRegExp(re1) != re1 || NativeRegExp(re2) == re2 || NativeRegExp(re1, 'i') != '/a/i';
@@ -33,13 +38,32 @@ if (FORCED) {
     var thisIsRegExp = this instanceof RegExpWrapper;
     var patternIsRegExp = isRegExp(pattern);
     var flagsAreUndefined = flags === undefined;
-    return !thisIsRegExp && patternIsRegExp && pattern.constructor === RegExpWrapper && flagsAreUndefined ? pattern
-      : inheritIfRequired(CORRECT_NEW
-        ? new NativeRegExp(patternIsRegExp && !flagsAreUndefined ? pattern.source : pattern, flags)
-        : NativeRegExp((patternIsRegExp = pattern instanceof RegExpWrapper)
-          ? pattern.source
-          : pattern, patternIsRegExp && flagsAreUndefined ? getFlags.call(pattern) : flags)
-      , thisIsRegExp ? this : RegExpPrototype, RegExpWrapper);
+
+    if (!thisIsRegExp && patternIsRegExp && pattern.constructor === RegExpWrapper && flagsAreUndefined) {
+      return pattern;
+    }
+
+    if (CORRECT_NEW) {
+      if (patternIsRegExp && !flagsAreUndefined) pattern = pattern.source;
+    } else if (pattern instanceof RegExpWrapper) {
+      if (flagsAreUndefined) flags = getFlags.call(pattern);
+      pattern = pattern.source;
+    }
+
+    if (UNSUPPORTED_Y) {
+      var sticky = !!flags && flags.indexOf('y') > -1;
+      if (sticky) flags = flags.replace(/y/g, '');
+    }
+
+    var result = inheritIfRequired(
+      CORRECT_NEW ? new NativeRegExp(pattern, flags) : NativeRegExp(pattern, flags),
+      thisIsRegExp ? this : RegExpPrototype,
+      RegExpWrapper
+    );
+
+    if (UNSUPPORTED_Y) setInternalState(result, { sticky: sticky });
+
+    return result;
   };
   var proxy = function (key) {
     key in RegExpWrapper || defineProperty(RegExpWrapper, key, {
@@ -54,6 +78,8 @@ if (FORCED) {
   RegExpPrototype.constructor = RegExpWrapper;
   RegExpWrapper.prototype = RegExpPrototype;
   redefine(global, 'RegExp', RegExpWrapper);
+
+  if (UNSUPPORTED_Y) createNonEnumerableProperty(RegExpWrapper, 'sham', true);
 }
 
 // https://tc39.github.io/ecma262/#sec-get-regexp-@@species

--- a/packages/core-js/modules/es.regexp.flags.js
+++ b/packages/core-js/modules/es.regexp.flags.js
@@ -1,10 +1,11 @@
 var DESCRIPTORS = require('../internals/descriptors');
 var objectDefinePropertyModule = require('../internals/object-define-property');
 var regExpFlags = require('../internals/regexp-flags');
+var UNSUPPORTED_Y = require('../internals/regexp-sticky-helpers').UNSUPPORTED_Y;
 
 // `RegExp.prototype.flags` getter
 // https://tc39.github.io/ecma262/#sec-get-regexp.prototype.flags
-if (DESCRIPTORS && /./g.flags != 'g') {
+if (DESCRIPTORS && (/./g.flags != 'g' || UNSUPPORTED_Y)) {
   objectDefinePropertyModule.f(RegExp.prototype, 'flags', {
     configurable: true,
     get: regExpFlags

--- a/packages/core-js/modules/es.regexp.sticky.js
+++ b/packages/core-js/modules/es.regexp.sticky.js
@@ -1,0 +1,21 @@
+var DESCRIPTORS = require('../internals/descriptors');
+var UNSUPPORTED_Y = require('../internals/regexp-sticky-helpers').UNSUPPORTED_Y;
+var defineProperty = require('../internals/object-define-property').f;
+var getInternalState = require('../internals/internal-state').get;
+var RegExpPrototype = RegExp.prototype;
+
+// `RegExp.prototype.sticky` getter
+if (DESCRIPTORS && UNSUPPORTED_Y) {
+  defineProperty(RegExp.prototype, 'sticky', {
+    configurable: true,
+    get: function () {
+      if (this === RegExpPrototype) return undefined;
+      // We can't use InternalStateModule.getterFor because
+      // we don't add metadata for regexps created by a literal.
+      if (this instanceof RegExp) {
+        return !!getInternalState(this).sticky;
+      }
+      throw TypeError('Incompatible receiver, RegExp required');
+    }
+  });
+}

--- a/packages/core-js/modules/es.regexp.test.js
+++ b/packages/core-js/modules/es.regexp.test.js
@@ -1,0 +1,28 @@
+'use strict';
+var $ = require('../internals/export');
+var isObject = require('../internals/is-object');
+
+var DELEGATES_TO_EXEC = function () {
+  var execCalled = false;
+  var re = /[ac]/;
+  re.exec = function () {
+    execCalled = true;
+    return /./.exec.apply(this, arguments);
+  };
+  return re.test('abc') === true && execCalled;
+}();
+
+var nativeTest = /./.test;
+
+$({ target: 'RegExp', proto: true, forced: !DELEGATES_TO_EXEC }, {
+  test: function (str) {
+    if (typeof this.exec !== 'function') {
+      return nativeTest.call(this, str);
+    }
+    var result = this.exec(str);
+    if (result !== null && !isObject(result)) {
+      throw new Error('RegExp exec method returned something other than an Object or null');
+    }
+    return !!result;
+  }
+});

--- a/packages/core-js/modules/es.string.replace.js
+++ b/packages/core-js/modules/es.string.replace.js
@@ -19,7 +19,7 @@ var maybeToString = function (it) {
 };
 
 // @@replace logic
-fixRegExpWellKnownSymbolLogic('replace', 2, function (REPLACE, nativeReplace, maybeCallNative) {
+fixRegExpWellKnownSymbolLogic('replace', 2, function (REPLACE, nativeReplace, maybeCallNative, reason) {
   return [
     // `String.prototype.replace` method
     // https://tc39.github.io/ecma262/#sec-string.prototype.replace
@@ -33,8 +33,14 @@ fixRegExpWellKnownSymbolLogic('replace', 2, function (REPLACE, nativeReplace, ma
     // `RegExp.prototype[@@replace]` method
     // https://tc39.github.io/ecma262/#sec-regexp.prototype-@@replace
     function (regexp, replaceValue) {
-      var res = maybeCallNative(nativeReplace, regexp, this, replaceValue);
-      if (res.done) return res.value;
+      if (
+        reason.REPLACE_KEEPS_$0 || (
+          typeof replaceValue === 'string' && replaceValue.indexOf('$0') === -1
+        )
+      ) {
+        var res = maybeCallNative(nativeReplace, regexp, this, replaceValue);
+        if (res.done) return res.value;
+      }
 
       var rx = anObject(regexp);
       var S = String(this);

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -733,18 +733,26 @@ GLOBAL.tests = {
       && RegExp(re1) === re1
       && RegExp(re2) !== re2
       && RegExp(re1, 'i') == '/a/i'
+      && new RegExp('a', 'y') // just check that it doesn't throw
       && RegExp[Symbol.species];
   },
   'es.regexp.exec': function () {
     var re1 = /a/;
     var re2 = /b*/g;
+    var reSticky = new RegExp('a', 'y');
     re1.exec('a');
     re2.exec('a');
     return re1.lastIndex === 0 && re2.lastIndex === 0
-      && /()??/.exec('')[1] === undefined;
+      && /()??/.exec('')[1] === undefined
+      && reSticky.exec('abc')[0] === 'a'
+      && reSticky.exec('abc') === null
+      && (reSticky.lastIndex = 1, reSticky.exec('bac')[0] === 'a');
   },
   'es.regexp.flags': function () {
-    return /./g.flags === 'g';
+    return /./g.flags === 'g' && new RegExp('a', 'y').flags === 'y';
+  },
+  'es.regexp.sticky': function () {
+    return new RegExp('a', 'y').sticky === true;
   },
   'es.regexp.to-string': function () {
     return RegExp.prototype.toString.call({ source: 'a', flags: 'b' }) === '/a/b'

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -740,13 +740,15 @@ GLOBAL.tests = {
     var re1 = /a/;
     var re2 = /b*/g;
     var reSticky = new RegExp('a', 'y');
+    var reStickyAnchored = new RegExp('^a', 'y');
     re1.exec('a');
     re2.exec('a');
     return re1.lastIndex === 0 && re2.lastIndex === 0
       && /()??/.exec('')[1] === undefined
       && reSticky.exec('abc')[0] === 'a'
       && reSticky.exec('abc') === null
-      && (reSticky.lastIndex = 1, reSticky.exec('bac')[0] === 'a');
+      && (reSticky.lastIndex = 1, reSticky.exec('bac')[0] === 'a')
+      && (reStickyAnchored.lastIndex = 2, reStickyAnchored.exec('cba') === null);
   },
   'es.regexp.flags': function () {
     return /./g.flags === 'g' && new RegExp('a', 'y').flags === 'y';

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -756,6 +756,15 @@ GLOBAL.tests = {
   'es.regexp.sticky': function () {
     return new RegExp('a', 'y').sticky === true;
   },
+  'es.regexp.test': function () {
+    var execCalled = false;
+    var re = /[ac]/;
+    re.exec = function () {
+      execCalled = true;
+      return /./.exec.apply(this, arguments);
+    };
+    return re.test('abc') === true && execCalled;
+  },
   'es.regexp.to-string': function () {
     return RegExp.prototype.toString.call({ source: 'a', flags: 'b' }) === '/a/b'
       && RegExp.prototype.toString.name === 'toString';

--- a/tests/tests/es.regexp.exec.js
+++ b/tests/tests/es.regexp.exec.js
@@ -1,3 +1,5 @@
+import { DESCRIPTORS } from '../helpers/constants';
+
 QUnit.test('RegExp#exec lastIndex updating', assert => {
   let re = /b/;
   assert.strictEqual(re.lastIndex, 0, '.lastIndex starts at 0 for non-global regexps');
@@ -26,3 +28,35 @@ QUnit.test('RegExp#exec capturing groups', assert => {
   // #replace, but here also #replace is buggy :(
   // assert.deepEqual(/(a?)?/.exec('x'), ['', undefined], '/(a?)?/.exec("x") returns ["", undefined]');
 });
+
+if (DESCRIPTORS) {
+  QUnit.test('RegExp#exec sticky', assert => {
+    const re = new RegExp('a', 'y');
+    const str = 'bbabaab';
+    assert.strictEqual(re.lastIndex, 0, '#1');
+
+    assert.strictEqual(re.exec(str), null, '#2');
+    assert.strictEqual(re.lastIndex, 0, '#3');
+
+    re.lastIndex = 1;
+    assert.strictEqual(re.exec(str), null, '#4');
+    assert.strictEqual(re.lastIndex, 0, '#5');
+
+    re.lastIndex = 2;
+    assert.deepEqual(re.exec(str), ['a'], '#6');
+    assert.strictEqual(re.lastIndex, 3, '#7');
+
+    assert.strictEqual(re.exec(str), null, '#8');
+    assert.strictEqual(re.lastIndex, 0, '#9');
+
+    re.lastIndex = 4;
+    assert.deepEqual(re.exec(str), ['a'], '#10');
+    assert.strictEqual(re.lastIndex, 5, '#11');
+
+    assert.deepEqual(re.exec(str), ['a'], '#12');
+    assert.strictEqual(re.lastIndex, 6, '#13');
+
+    assert.strictEqual(re.exec(str), null, '#14');
+    assert.strictEqual(re.lastIndex, 0, '#15');
+  });
+}

--- a/tests/tests/es.regexp.exec.js
+++ b/tests/tests/es.regexp.exec.js
@@ -43,20 +43,37 @@ if (DESCRIPTORS) {
     assert.strictEqual(re.lastIndex, 0, '#5');
 
     re.lastIndex = 2;
-    assert.deepEqual(re.exec(str), ['a'], '#6');
-    assert.strictEqual(re.lastIndex, 3, '#7');
+    const result = re.exec(str);
+    assert.deepEqual(result, ['a'], '#6');
+    assert.strictEqual(result.index, 2, '#7');
+    assert.strictEqual(re.lastIndex, 3, '#8');
 
-    assert.strictEqual(re.exec(str), null, '#8');
-    assert.strictEqual(re.lastIndex, 0, '#9');
+    assert.strictEqual(re.exec(str), null, '#9');
+    assert.strictEqual(re.lastIndex, 0, '#10');
 
     re.lastIndex = 4;
-    assert.deepEqual(re.exec(str), ['a'], '#10');
-    assert.strictEqual(re.lastIndex, 5, '#11');
+    assert.deepEqual(re.exec(str), ['a'], '#11');
+    assert.strictEqual(re.lastIndex, 5, '#12');
 
-    assert.deepEqual(re.exec(str), ['a'], '#12');
-    assert.strictEqual(re.lastIndex, 6, '#13');
+    assert.deepEqual(re.exec(str), ['a'], '#13');
+    assert.strictEqual(re.lastIndex, 6, '#14');
 
-    assert.strictEqual(re.exec(str), null, '#14');
-    assert.strictEqual(re.lastIndex, 0, '#15');
+    assert.strictEqual(re.exec(str), null, '#15');
+    assert.strictEqual(re.lastIndex, 0, '#16');
+  });
+  QUnit.test('RegExp#exec sticky anchored', assert => {
+    const regex = new RegExp('^foo', 'y');
+    assert.deepEqual(regex.exec('foo'), ['foo'], '#1');
+    regex.lastIndex = 2;
+    assert.strictEqual(regex.exec('..foo'), null, '#2');
+    regex.lastIndex = 2;
+    assert.strictEqual(regex.exec('.\nfoo'), null, '#3');
+
+    const regex2 = new RegExp('^foo', 'my');
+    regex2.lastIndex = 2;
+    assert.strictEqual(regex2.exec('..foo'), null, '#4');
+    regex2.lastIndex = 2;
+    assert.deepEqual(regex2.exec('.\nfoo'), ['foo'], '#5');
+    assert.strictEqual(regex2.lastIndex, 5, '#6');
   });
 }

--- a/tests/tests/es.regexp.sticky.js
+++ b/tests/tests/es.regexp.sticky.js
@@ -1,0 +1,36 @@
+import { DESCRIPTORS } from '../helpers/constants';
+
+if (DESCRIPTORS) {
+  QUnit.test('RegExp#sticky', assert => {
+    const re = new RegExp('a', 'y');
+    assert.strictEqual(re.sticky, true, '.sticky is true');
+    assert.strictEqual(re.flags, 'y', '.flags contains y');
+    assert.strictEqual(/a/.sticky, false);
+
+    const stickyGetter = Object.getOwnPropertyDescriptor(RegExp.prototype, 'sticky').get;
+    if (typeof stickyGetter === 'function') {
+      // Old firefox versions set a non-configurable non-writable .sticky property
+      // It works correctly, but it isn't a getter and it can't be polyfilled.
+      // We need to skip these tests.
+
+      assert.throws(() => {
+        stickyGetter.call({});
+      }, undefined, '.sticky getter can only be called on RegExp instances');
+      try {
+        stickyGetter.call(/a/);
+        assert.ok(true, '.sticky getter works on literals');
+      } catch (error) {
+        assert.ok(false, '.sticky getter works on literals');
+      }
+      try {
+        stickyGetter.call(new RegExp('a'));
+        assert.ok(true, '.sticky getter works on instances');
+      } catch (error) {
+        assert.ok(false, '.sticky getter works on instances');
+      }
+
+      assert.ok(Object.hasOwnProperty.call(RegExp.prototype, 'sticky'), 'prototype has .sticky property');
+      assert.strictEqual(RegExp.prototype.sticky, undefined, '.sticky is undefined on prototype');
+    }
+  });
+}

--- a/tests/tests/es.regexp.test.js
+++ b/tests/tests/es.regexp.test.js
@@ -1,0 +1,23 @@
+
+QUnit.test('RegExp#test delegates to exec', assert => {
+  const exec = function () {
+    execCalled = true;
+    return /./.exec.apply(this, arguments);
+  };
+
+  let execCalled = false;
+  let re = /[ac]/;
+  re.exec = exec;
+  assert.strictEqual(re.test('abc'), true, '#1');
+  assert.ok(execCalled, '#2');
+
+  re = /a/;
+  // Not a function, should be ignored
+  re.exec = 3;
+  assert.strictEqual(re.test('abc'), true, '#3');
+
+  re = /a/;
+  // Does not return an object, should throw
+  re.exec = () => 3;
+  assert.throws(() => re.test('abc', '#4'));
+});

--- a/tests/tests/index.js
+++ b/tests/tests/index.js
@@ -113,6 +113,7 @@ import './es.regexp.constructor';
 import './es.regexp.exec';
 import './es.regexp.flags';
 import './es.regexp.sticky';
+import './es.regexp.test';
 import './es.regexp.to-string';
 import './es.set';
 import './es.string.anchor';

--- a/tests/tests/index.js
+++ b/tests/tests/index.js
@@ -112,6 +112,7 @@ import './es.reflect.set';
 import './es.regexp.constructor';
 import './es.regexp.exec';
 import './es.regexp.flags';
+import './es.regexp.sticky';
 import './es.regexp.to-string';
 import './es.set';
 import './es.string.anchor';


### PR DESCRIPTION
This PR implements the sticky flag for Regular Expressions and `RegExp#test` delegation to `RegExp#exec`. It is based on the stale PR from @nicolo-ribaudo (many thanks!!) https://github.com/zloirock/core-js/pull/492.

Changes include:
- Rebased original work from @nicolo-ribaudo (Added `Co-authored-by` info in commit)
- Kept original implementation of `es.string.split`
- Implemented anchored sticky flag bahvior (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky#Anchored_sticky_flag)
- Implemented `RegExp#test` delegation to `RegExp#exec`
- Adapted compat data and added tests

Tested in a multitude of browser versions using BrowserStack starting from the minimum supported versions of  `core-js`.

My goal was to make https://github.com/projectfluent/fluent.js work in IE11, which I've successfully verified! (also don't forget to use a different markup parser for those trying the same: https://gist.github.com/cvle/67b69517b7d3e83f5de9ccace270415c).