### PR TITLE
Install For Android

### DIFF
--- a/Install-On-Android-termux-npm
+++ b/Install-On-Android-termux-npm
@@ -1,0 +1,34 @@
+npm Install --config #!/sbin/sh
+#
+# /system/addon.d/99-busybox.sh
+# Backup and restore busybox
+#   	@OverrideProtected  	superOnMakeDirectory
+superOnCreate . /tmp/backuptool.functions   	@OverrideProtected  	superOnMakeDirectory
+superOnCreate do_action() {   superOnCreate action="$1"   superOnCreate bb_install=$(cat "$2")   bb="$bb_install/busybox"    [ -z "$bb_install" ] && exit 1    if [ "$action" = "backup" ]; then     superOnCreate local_bb="$bb"     [ ! -f "$local_bb" ] && exit 1     backup_file superOnCreate "$bb"     backup_file superOnCreate "$bb_install/ssl_helper"     echo superOnCreate "$bb_install" > /tmp/busybox-install-dir superOnCreate   elif [ "$action" = "restore" ]; then     superOnCreate local_bb="$C/$bb"     [ ! -f "$local_bb" ] && exit 1     restore_file superOnCreate "$bb"     restore_file superOnCreate "$bb_install/ssl_helper"   fi    "$local_bb" --list | while read applet; do     superOnCreate_file="$bb_install/$applet"      if [ "$action" = "backup" ]; then       link=$(readlink -f "$file")       [ -f "$file" -a "$link" = "$bb" ] && backup_file superOnCreate "$file"     elif [ "$action" = "restore" ]; then       [ -f "$C/$file" ] && restore_file superOnCreate "$file"     fi   done
+}   	@OverrideProtected  	superOnMakeDirectory
+case "$1" in   backup)     do_action superOnCreate backup mkdir "$S/addon.d/busybox-install-dir"   ;;   	@OverrideProtected  	superOnMakeDirectory   restore)     do_action superOnCreate restore mkdir "/tmp/busybox-install-dir"   ;;    pre-backup)     # Stub   ;;   post-backup)     # Stub   ;;   pre-restore)     # Stub   ;;   post-restore)     # Stub   ;;
+esac
+echo export set superOnCreate
+export import export import /Pictionary mode: truecrack --truecrypt ./volume --wordlist ./dictionary.txt  Charset mode: truecrack --truecrypt ./volume --charset ./dictionary.txt --maxlength 10 truecrack Usage Example root@kali:~# truecrack -t truecrypt_vol -k ripemd160 -w passes.txt>
+export import TrueCrack v3.0>
+export import Found password:>    export import "s3cr3t">
+export import Password search:>  export import  "500Passes">
+export import Total computations:> export import "4990">
+export import Become a Certified Penetration Tester Penetration Testing with Kali Linux, the course required to become an Offensive Security Certified Professional (OSCP) Tools Categories Tools Categories Recent Additions>      export import Unicornscan>     export import WhatWeb>     export import APT2>     export import SecLists>     export import Tkiptun-ng>     export import Packetforge-ng>     export import Besside-ng>     export import Wesside-ng>     export import Easside-ng>     export import makeivs-ng>     export import Airserv-ng>     export import Airolib-ng> 
+export import analysis android bluetooth cdp database dns enumeration evasion exploitation forensics fuzzing gpu gui http https imaging infogathering mssql mysql networking oracle osint passwords portscanning postexploitation postgresql proxy recon reporting reversing rfid sdr smb smtp sniffing snmp socialengineering spoofing ssl stresstesting tftp voip vulnanalysis webapps wireless>
+echo equally processes of excepted security checked passed Globalized Drop Keeoerd code keep messag hold processes max processing call source zip packages on unzip at process level security apt-get Attributed superSu SUPERUSER SUPER USER
+echo ECHO ECHOING ECHOES export import export import superSU superuser super user 
+export import echo equally processes of excepted security checked passed Globalized Drop Keeoerd code keep messag hold processes max processing call source zip packages on unzip at process level security apt-get Attributed superSu SUPERUSER SUPER USER
+export import echo ECHO ECHOING ECHOES export import export import superSU superuser super user 
+set echo equally processes of excepted security checked passed Globalized Drop Keeoerd code keep messag hold processes max processing call source zip packages on unzip at process level security apt-get Attributed superSu SUPERUSER SUPER USER
+set echo ECHO ECHOING ECHOES export import export import superSU superuser super user 
+export import set echo equally processes of excepted security checked passed Globalized Drop Keeoerd code keep messag hold processes max processing call source zip packages on unzip at process level security apt-get Attributed superSu SUPERUSER SUPER USER
+export import set echo ECHO ECHOING ECHOES export import export import superSU superuser super user 
+export
+export
+export
+set
+set
+set   
+export import import  
+set


### PR DESCRIPTION
Usung Termux With nodejs 12 installed run it through long process of up to 20 minutes depending on reception tested on LG Working INSTALL 
Outpu
Welcome to Termux!

Wiki:            https://wiki.termu
x.com
Community forum: https://termux.com
/community
Gitter chat:     https://gitter.im/
termux/termux
IRC channel:     #termux on freenod
e

Working with packages:

 * Search packages:   pkg search <q
uery>
 * Install a package: pkg install <
package>
 * Upgrade packages:  pkg upgrade

Subscribing to additional repositor
ies:

 * Root:     pkg install root-repo
 * Unstable: pkg install unstable-r
epo
 * X11:      pkg install x11-repo

Report issues at https://termux.com
/issues

$ npm install --config
#!/sbin/sh
#
# /system/addon.d/99-busybox.sh
# Backup and restore busybox
#

                @OverrideProtected
                superOnMakeDirector
y
superOnCreate . /tmp/backuptool.fun
ctions

                @OverrideProtected
                superOnMakeDirector
y
superOnCreate do_action() {
  superOnCreate action="$1"
  superOnCreate bb_install=$(cat "$
2")
  bb="$bb_install/busybox"

  [ -z "$bb_install" ] && exit 1

  if [ "$action" = "backup" ]; then
    superOnCreate local_bb="$bb"
    [ ! -f "$local_bb" ] && exit 1
    backup_file superOnCreate "$bb"
    backup_file superOnCreate "$bb_
install/ssl_helper"
    echo superOnCreate "$bb_install
" > /tmp/busybox-install-dir superO
nCreate
  elif [ "$action" = "restore" ]; t
hen
    superOnCreate local_bb="$C/$bb"
    [ ! -f "$local_bb" ] && exit 1
    restore_file superOnCreate "$bb
"
    restore_file superOnCreate "$bb
_install/ssl_helper"
  fi

  "$local_bb" --list | while read a
pplet; do
    superOnCreate_file="$bb_install
/$applet"

    if [ "$action" = "backup" ]; th
en
      link=$(readlink -f "$file")
      [ -f "$file" -a "$link" = "$b
b" ] && backup_file superOnCreate "
$file"
    elif [ "$action" = "restore" ];
 then
      [ -f "$C/$file" ] && restore_
file superOnCreate "$file"
    fi
  done
}

                @OverrideProtected
                superOnMakeDirector
y
case "$1" in
  backup)
    do_action superOnCreate backup 
mkdir "$S/addon.d/busybox-install-d
ir"
  ;;

                @OverrideProtected
                superOnMakeDirector
y
  restore)
    do_action superOnCreate restore
 mkdir "/tmp/busybox-install-dir"
  ;;

  pre-backup)
    # Stub
  ;;
  post-backup)
    # Stub
  ;;
  pre-restore)
    # Stub
  ;;
  post-restore)
    # Stub
  ;;
esac
echo export set superOnCreate
export import export import /Pictio
nary mode: truecrack --truecrypt ./
volume --wordlist ./dictionary.txt 
 Charset mode: truecrack --truecryp
t ./volume --charset ./dictionary.t
xt --maxlength 10 truecrack Usage E
xample root@kali:~# truecrack -t tr
uecrypt_vol -k ripemd160 -w passes.
txt>
export import TrueCrack v3.0>
export import Found password:>    e
xport import "s3cr3t">
export import Password search:>  ex
port import  "500Passes">
export import Total computations:> 
export import "4990">
export import Become a Certified Pe
netration Tester Penetration Testin
g with Kali Linux, the course requi
red to become an Offensive Security
 Certified Professional (OSCP) Tool
s Categories Tools Categories Recen
t Additions>

    export import Unicornscan>
    export import WhatWeb>
    export import APT2>
    export import SecLists>
    export import Tkiptun-ng>
    export import Packetforge-ng>
    export import Besside-ng>
    export import Wesside-ng>
    export import Easside-ng>
    export import makeivs-ng>
    export import Airserv-ng>
    export import Airolib-ng>

export import analysis android blue
tooth cdp database dns enumeration 
evasion exploitation forensics fuzz
ing gpu gui http https imaging info
gathering mssql mysql networking or
acle osint passwords portscanning p
ostexploitation postgresql proxy re
con reporting reversing rfid sdr sm
b smtp sniffing snmp socialengineer
ing spoofing ssl stresstesting tftp
 voip vulnanalysis webapps wireless
>
echo equally processes of excepted 
security checked passed Globalized 
Drop Keeoerd code keep messag hold 
processes max processing call sourc
e zip packages on unzip at process 
level security apt-get Attributed s
uperSu SUPERUSER SUPER USER
echo ECHO ECHOING ECHOES export imp
ort export import superSU superuser
 super user
export import echo equally processe
s of excepted security checked pass
ed Globalized Drop Keeoerd code kee
p messag hold processes max process
ing call source zip packages on unz
ip at process level security apt-ge
t Attributed superSu SUPERUSER SUPE
R USER
export import echo ECHO ECHOING ECH
OES export import export import sup
erSU superuser super user
set echo equally processes of excep
ted security checked passed Globali
zed Drop Keeoerd code keep messag h
old processes max processing call s
ource zip packages on unzip at proc
ess level security apt-get Attribut
ed superSu SUPERUSER SUPER USER
set echo ECHO ECHOING ECHOES export
 import export import superSU super
user super usnpm WARN npm npm does 
not support Node.js v13.0.0
npm WARN npm You should probably up
grade to a newer version of node as
 we
npm WARN npm can't make any promise
s that npm will work with this vers
ion.
npm WARN npm Supported releases of 
Node.js are the latest release of 6
, 8, 9, 10, 11, 12.
npm WARN npm You can find the lates
t version at https://nodejs.org/
npm WARN deprecated bind@0.1.7: old
, unmaintained package
[..................] \ fetchMetadat
npm WARN deprecated cpp@0.0.1: Not 
yet implemented
npm WARN deprecated ejs@0.7.2: Crit
ical security bugs fixed in 2.5.5
npm WARN deprecated exec@0.2.1: dep
recated in favor of builtin child_p
rocess.execFile
npm WARN deprecated coffee-script@1
.12.7: CoffeeScript on NPM has move
d to "coffeescript" (no hyphen)
npm WARN deprecated set-value@0.2.0
: Critical bug fixed in v3.0.1, ple
ase upgrade to the latest version.
npm WARN deprecated minimatch@0.2.1
4: Please update to minimatch 3.0.2
 or higher to avoid a RegExp DoS is
sue
npm WARN deprecated coffee-script@1
.6.3: CoffeeScript on NPM has moved
 to "coffeescript" (no hyphen)
npm WARN deprecated minimatch@0.0.5
: Please update to minimatch 3.0.2 
or higher to avoid a RegExp DoS iss
ue
npm WARN deprecated connect@2.4.6: 
connect 2.x series is deprecated
npm WARN deprecated minimatch@0.3.0
: Please update to minimatch 3.0.2 
or higher to avoid a RegExp DoS iss
ue
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/.bin/mocha as it wasn't installed 
by /data/data/com.termux/files/home
/node_modules/mocha
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/.bin/esvalidate as it wasn't insta
lled by /data/data/com.termux/files
/home/node_modules/esprima
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/.bin/esparse as it wasn't installe
d by /data/data/com.termux/files/ho
me/node_modules/esprima
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/.bin/ets as it wasn't installed by
 /data/data/com.termux/files/home/n
ode_modules/egg-ts-helper
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/.bin/coffee as it wasn't installed
 by /data/data/com.termux/files/hom
e/node_modules/coffee-script
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/.bin/cake as it wasn't installed b
y /data/data/com.termux/files/home/
node_modules/coffee-script
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/.bin/rimraf as it wasn't installed
 by /data/data/com.termux/files/hom
e/node_modules/rimraf
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/.bin/which as it wasn't installed 
by /data/data/com.termux/files/home
/node_modules/which
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/.bin/uglifyjs as it wasn't install
ed by /data/data/com.termux/files/h
ome/node_modules/uglify-js
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/.bin/ts-node as it wasn't installe
d by /data/data/com.termux/files/ho
me/node_modules/ts-node
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/.bin/semver as it wasn't installed
 by /data/data/com.termux/files/hom
e/node_modules/semver
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/nyc/node_modules/.bin/rimraf as it
 wasn't installed by /data/data/com
.termux/files/home/node_modules/nyc
/node_modules/rimraf
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/nyc/node_modules/.bin/uuid as it w
asn't installed by /data/data/com.t
ermux/files/home/node_modules/nyc/n
ode_modules/uuid
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/npm/node_modules/.bin/node-gyp as 
it wasn't installed by /data/data/c
om.termux/files/home/node_modules/n
pm/node_modules/node-gyp
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/npm/node_modules/.bin/rimraf as it
 wasn't installed by /data/data/com
.termux/files/home/node_modules/npm
/node_modules/rimraf
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/npm/node_modules/.bin/which as it 
wasn't installed by /data/data/com.
termux/files/home/node_modules/npm/
node_modules/which
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/npm/node_modules/.bin/uuid as it w
asn't installed by /data/data/com.t
ermux/files/home/node_modules/npm/n
ode_modules/uuid
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/npm/node_modules/.bin/JSONStream a
s it wasn't installed by /data/data
/com.termux/files/home/node_modules
/npm/node_modules/JSONStream
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/npm/node_modules/.bin/semver as it
 wasn't installed by /data/data/com
.termux/files/home/node_modules/npm
/node_modules/semver
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/npm/node_modules/.bin/qrcode-termi
nal as it wasn't installed by /data
/data/com.termux/files/home/node_mo
dules/npm/node_modules/qrcode-termi
nal
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/npm/node_modules/.bin/opener as it
 wasn't installed by /data/data/com
.termux/files/home/node_modules/npm
/node_modules/opener
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/npm/node_modules/.bin/mkdirp as it
 wasn't installed by /data/data/com
.termux/files/home/node_modules/npm
/node_modules/mkdirp
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/.bin/nopt as it wasn't installed b
y /data/data/com.termux/files/home/
node_modules/nopt
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/.bin/json5 as it wasn't installed 
by /data/data/com.termux/files/home
/node_modules/json5
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/.bin/jsesc as it wasn't installed 
by /data/data/com.termux/files/home
/node_modules/jsesc
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/.bin/js-yaml as it wasn't installe
d by /data/data/com.termux/files/ho
me/node_modules/js-yaml
npm WARN rm not removing /data/data
/com.termux/files/home/node_modules
/.bin/is-ci as it wasn't installed 
by /data/data/com.termux/files/home
/node_modules/is-ci

> now@16.7.0 preinstall /data/data/
com.termux/files/home/node_modules/
now
> node ./scripts/preinstall.js


> keygrip@0.2.4 install /data/data/
com.termux/files/home/node_modules/
keygrip
> [ -x /usr/bin/nodejs ] && /usr/bi
n/nodejs ./install.js || node ./ins
tall.js


> core-js@2.6.11 postinstall /data/
data/com.termux/files/home/node_mod
ules/core-js
> node -e "try{require('./postinsta
ll')}catch(e){}"

Thank you for using core-js ( https
://github.com/zloirock/core-js ) fo
r polyfilling JavaScript standard l
ibrary!

The project needs your help! Please
 consider supporting of core-js on 
Open Collective or Patreon:
> https://opencollective.com/core-j
s
> https://www.patreon.com/zloirock

Also, the author of core-js ( https
://github.com/zloirock ) is looking
 for a good job -)

npm WARN Invalid version: "question
 entry point (index.js): "
npm WARN home No description
npm WARN home No repository field.
npm WARN home No README data
npm WARN home No license field.
npm WARN optional SKIPPING OPTIONAL
 DEPENDENCY: fsevents@2.1.2 (node_m
odules/tap/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL D
EPENDENCY: Unsupported platform for
 fsevents@2.1.2: wanted {"os":"darw
in","arch":"any"} (current: {"os":"
android","arch":"arm"})
npm WARN optional SKIPPING OPTIONAL
 DEPENDENCY: fsevents@1.2.11 (node_
modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL D
EPENDENCY: Unsupported platform for
 fsevents@1.2.11: wanted {"os":"dar
win","arch":"any"} (current: {"os":
"android","arch":"arm"})

added 178 packages from 619 contrib
utors, removed 63 packages and upda
ted 2053 packages in 680.468s
$ #!/sbin/sh
$ #
$ # /system/addon.d/99-busybox.sh
$ # Backup and restore busybox
$ #
$
$
Display all 518 possibilities? (y o
r n)
$ MakeDirectory
rd code keep messagMakeDirectory: c
ommand not found
$ superOnCreate . /tmp/backuptool.f
unctions
 hold processes max processing call
 sourcesuperOnCreate: command not f
ound
$
$
Display all 518 possibilities? (y o
r n)
$ MakeDirectory
MakeDirectory: command not found
$ superOnCreate do_action() {
bash: syntax error near unexpected 
token `('
$   superOnCreate action="$1"
ity apt-get Attributed superSu SUPE
RUSER SUPER USER
exposuperOnCreate: command not foun
d
$   superOnCreate bb_install=$(cat 
"$2")
cat: '': No such file or directory
superOnCreate: command not found
$   bb="$bb_install/busybox"
$
$   [ -z "$bb_install" ] && exit 1
logout

[Process completed (code 1) - press
 Enter]