### PR TITLE
fixes #471

### DIFF
--- a/packages/core-js/internals/fix-regexp-well-known-symbol-logic.js
+++ b/packages/core-js/internals/fix-regexp-well-known-symbol-logic.js
@@ -28,6 +28,14 @@ var REPLACE_KEEPS_$0 = (function () {
   return 'a'.replace(/./, '$0') === '$0';
 })();
 
+// Safari <= 13.0.3(?) substitutes nth capture where n>m with an empty string
+var REGEXP_REPLACE_SUBSTITUTES_UNDEFINED_CAPTURE = (function () {
+  if (RegExp.prototype['Symbol.replace']) {
+    return RegExp.prototype['Symbol.replace'].call(/./, 'a', '$0') === '';
+  }
+  return false;
+})();
+
 // Chrome 51 has a buggy "split" implementation when RegExp#exec !== nativeExec
 // Weex JS has frozen built-in prototypes, so use try / catch wrapper
 var SPLIT_WORKS_WITH_OVERWRITTEN_EXEC = !fails(function () {
@@ -75,7 +83,9 @@ module.exports = function (KEY, length, exec, sham) {
   if (
     !DELEGATES_TO_SYMBOL ||
     !DELEGATES_TO_EXEC ||
-    (KEY === 'replace' && !(REPLACE_SUPPORTS_NAMED_GROUPS && REPLACE_KEEPS_$0)) ||
+    (KEY === 'replace' && !(REPLACE_SUPPORTS_NAMED_GROUPS && (
+      REPLACE_KEEPS_$0 || REGEXP_REPLACE_SUBSTITUTES_UNDEFINED_CAPTURE
+    ))) ||
     (KEY === 'split' && !SPLIT_WORKS_WITH_OVERWRITTEN_EXEC)
   ) {
     var nativeRegExpMethod = /./[SYMBOL];
@@ -90,7 +100,10 @@ module.exports = function (KEY, length, exec, sham) {
         return { done: true, value: nativeMethod.call(str, regexp, arg2) };
       }
       return { done: false };
-    }, { REPLACE_KEEPS_$0: REPLACE_KEEPS_$0 });
+    }, {
+      REPLACE_KEEPS_$0: REPLACE_KEEPS_$0,
+      REGEXP_REPLACE_SUBSTITUTES_UNDEFINED_CAPTURE: REGEXP_REPLACE_SUBSTITUTES_UNDEFINED_CAPTURE
+    });
     var stringMethod = methods[0];
     var regexMethod = methods[1];
 

--- a/packages/core-js/internals/fix-regexp-well-known-symbol-logic.js
+++ b/packages/core-js/internals/fix-regexp-well-known-symbol-logic.js
@@ -30,8 +30,8 @@ var REPLACE_KEEPS_$0 = (function () {
 
 // Safari <= 13.0.3(?) substitutes nth capture where n>m with an empty string
 var REGEXP_REPLACE_SUBSTITUTES_UNDEFINED_CAPTURE = (function () {
-  if (RegExp.prototype['Symbol.replace']) {
-    return RegExp.prototype['Symbol.replace'].call(/./, 'a', '$0') === '';
+  if (RegExp.prototype[wellKnownSymbol('replace')]) {
+    return RegExp.prototype[wellKnownSymbol('replace')].call(/./, 'a', '$0') === '';
   }
   return false;
 })();

--- a/packages/core-js/internals/fix-regexp-well-known-symbol-logic.js
+++ b/packages/core-js/internals/fix-regexp-well-known-symbol-logic.js
@@ -28,10 +28,11 @@ var REPLACE_KEEPS_$0 = (function () {
   return 'a'.replace(/./, '$0') === '$0';
 })();
 
+var REPLACE = wellKnownSymbol('replace');
 // Safari <= 13.0.3(?) substitutes nth capture where n>m with an empty string
 var REGEXP_REPLACE_SUBSTITUTES_UNDEFINED_CAPTURE = (function () {
-  if (RegExp.prototype[wellKnownSymbol('replace')]) {
-    return RegExp.prototype[wellKnownSymbol('replace')].call(/./, 'a', '$0') === '';
+  if (/./[REPLACE]) {
+    return /./[REPLACE]('a', '$0') === '';
   }
   return false;
 })();
@@ -83,9 +84,11 @@ module.exports = function (KEY, length, exec, sham) {
   if (
     !DELEGATES_TO_SYMBOL ||
     !DELEGATES_TO_EXEC ||
-    (KEY === 'replace' && !(REPLACE_SUPPORTS_NAMED_GROUPS && (
-      REPLACE_KEEPS_$0 || REGEXP_REPLACE_SUBSTITUTES_UNDEFINED_CAPTURE
-    ))) ||
+    (KEY === 'replace' && !(
+      REPLACE_SUPPORTS_NAMED_GROUPS &&
+      REPLACE_KEEPS_$0 &&
+      REGEXP_REPLACE_SUBSTITUTES_UNDEFINED_CAPTURE
+    )) ||
     (KEY === 'split' && !SPLIT_WORKS_WITH_OVERWRITTEN_EXEC)
   ) {
     var nativeRegExpMethod = /./[SYMBOL];

--- a/packages/core-js/modules/es.string.replace.js
+++ b/packages/core-js/modules/es.string.replace.js
@@ -34,7 +34,7 @@ fixRegExpWellKnownSymbolLogic('replace', 2, function (REPLACE, nativeReplace, ma
     // https://tc39.github.io/ecma262/#sec-regexp.prototype-@@replace
     function (regexp, replaceValue) {
       if (
-        reason.REGEXP_REPLACE_SUBSTITUTES_UNDEFINED_CAPTURE &&
+        !reason.REGEXP_REPLACE_SUBSTITUTES_UNDEFINED_CAPTURE &&
         (reason.REPLACE_KEEPS_$0 || (typeof replaceValue === 'string' && replaceValue.indexOf('$0') === -1))
       ) {
         var res = maybeCallNative(nativeReplace, regexp, this, replaceValue);

--- a/packages/core-js/modules/es.string.replace.js
+++ b/packages/core-js/modules/es.string.replace.js
@@ -33,7 +33,10 @@ fixRegExpWellKnownSymbolLogic('replace', 2, function (REPLACE, nativeReplace, ma
     // `RegExp.prototype[@@replace]` method
     // https://tc39.github.io/ecma262/#sec-regexp.prototype-@@replace
     function (regexp, replaceValue) {
-      if (reason.REPLACE_KEEPS_$0 || (typeof replaceValue === 'string' && replaceValue.indexOf('$0') === -1)) {
+      if (
+        reason.REGEXP_REPLACE_SUBSTITUTES_UNDEFINED_CAPTURE &&
+        (reason.REPLACE_KEEPS_$0 || (typeof replaceValue === 'string' && replaceValue.indexOf('$0') === -1))
+      ) {
         var res = maybeCallNative(nativeReplace, regexp, this, replaceValue);
         if (res.done) return res.value;
       }


### PR DESCRIPTION
Fixes #471 in Safari. Not sure if this falls within the scope of core-js or not since the behavior of `$n` when n > m is supposed to be implementation-defined, which I think means Safari can do whatever they want?