### PR TITLE
Include promise polyfill for IE 11

### DIFF
--- a/packages/core-js-compat/src/data.js
+++ b/packages/core-js-compat/src/data.js
@@ -707,11 +707,13 @@ const data = {
     chrome: '67', // '51',
     firefox: '69',
     safari: '11.0',
+    ie: '11',
   },
   'es.promise.all-settled': {
     chrome: '76',
     firefox: '71',
     safari: '13',
+    ie: '11',
   },
   'es.promise.finally': {
     // V8 6.6 has a serious bug
@@ -721,6 +723,7 @@ const data = {
     // https://bugs.webkit.org/show_bug.cgi?id=200788
     ios: '13.2.3', // need to clarify the patch release, >13.0.0 && <= 13.2.3
     safari: '13.0.3', // need to clarify the patch release, >13.0.0 && <= 13.0.3
+    ie: '11',
   },
   'es.reflect.apply': {
     chrome: '49',


### PR DESCRIPTION
According to https://kangax.github.io/compat-table/es6/#test-Promise
we should include polyfill for promise in IE 11.

Mentioned in https://github.com/zloirock/core-js/issues/756