### PR TITLE
fix: some runtime can't use new Function

### DIFF
--- a/packages/core-js/internals/global.js
+++ b/packages/core-js/internals/global.js
@@ -10,4 +10,4 @@ module.exports =
   check(typeof self == 'object' && self) ||
   check(typeof global == 'object' && global) ||
   // eslint-disable-next-line no-new-func
-  Function('return this')();
+  (function () { return this; })() || Function('return this')();


### PR DESCRIPTION
There are some customized environments. New Function are not allowed .

this code is from regenerator

https://github.com/facebook/regenerator/blob/3db5564ff18e3f5bdafc4577522b41a006cc2c91/packages/regenerator-runtime/runtime-module.js#L10