### PR TITLE
Extend compat metadata for URL and URLSearchParams polyfills

### DIFF
--- a/packages/core-js-compat/src/data.js
+++ b/packages/core-js-compat/src/data.js
@@ -1506,19 +1506,26 @@ const data = {
     safari: '1.0',
   },
   'web.url': {
-    chrome: '67',
-    firefox: '57',
+    chrome: '51',
+    edge: '13',
+    firefox: '54',
     node: '10.0',
+    safari: '10.0'
   },
   'web.url.to-json': {
     chrome: '71',
-    firefox: '57',
+    edge: '17',
+    firefox: '54',
     node: '10.0',
+    safari: '10.0'
   },
   'web.url-search-params': {
-    chrome: '67',
-    firefox: '57',
+    chrome: '61',
+    edge: '17',
+    firefox: '54',
+    ios: '10.3',
     node: '10.0',
+    safari: '10.1'
   },
 };
 


### PR DESCRIPTION
Certain versions of edge and safari support URL, URLSearchParams and
URL.prototype.toJSON. However the compat data doesn't seem to note that,
thus leading for unnecessary polyfilling.

The updated data has been taken from MDN and caniuse:

- https://developer.mozilla.org/en-US/docs/Web/API/URL#Browser_compatibility
- https://caniuse.com/#feat=url
- https://caniuse.com/#feat=mdn-api_url_tojson
- https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams#Browser_compatibility
- https://caniuse.com/#feat=urlsearchparams