### PR TITLE
Fix typo in a comment

### DIFF
--- a/packages/core-js/modules/web.url-search-params.js
+++ b/packages/core-js/modules/web.url-search-params.js
@@ -162,7 +162,7 @@ var URLSearchParamsConstructor = function URLSearchParams(/* init */) {
 var URLSearchParamsPrototype = URLSearchParamsConstructor.prototype;
 
 redefineAll(URLSearchParamsPrototype, {
-  // `URLSearchParams.prototype.appent` method
+  // `URLSearchParams.prototype.append` method
   // https://url.spec.whatwg.org/#dom-urlsearchparams-append
   append: function append(name, value) {
     validateArgumentsLength(arguments.length, 2);


### PR DESCRIPTION
Just a tiny thing I noticed in URLSearchParams

`appent` => `append`