### PR TITLE
fix: resolve postMessage take a error on ios when protocol is file

### DIFF
--- a/packages/core-js/internals/task.js
+++ b/packages/core-js/internals/task.js
@@ -80,8 +80,8 @@ if (!set || !clear) {
     global.addEventListener &&
     typeof postMessage == 'function' &&
     !global.importScripts &&
-    !fails(post) &&
-    location.protocol !== 'file:'
+    location.protocol !== 'file:' &&
+    !fails(post)
   ) {
     defer = post;
     global.addEventListener('message', listener, false);


### PR DESCRIPTION
On my ios device, when I run html with file protocol, the console will get an error,
![image](https://user-images.githubusercontent.com/13299648/93627809-14012580-fa18-11ea-905d-352ec85c31ae.png)

Although [#771 ] has resolve this problem,  I think there has some other issue, because ```!fails(post)``` will run before ```location.protocol !== 'file:'``` ，and ```post``` method will be call,  then postMessage will be call. There was a problem
```
var post = function (id) {
  // old engines have not location.origin
  global.postMessage(id + '', location.protocol + '//' + location.host);
};
```

so I switch this position