### PR TITLE
[compat] IE10 supports String.prototype.trim()

### DIFF
--- a/packages/core-js-compat/src/data.js
+++ b/packages/core-js-compat/src/data.js
@@ -929,6 +929,7 @@ const data = {
     chrome: '59',
     edge: '15',
     firefox: '52',
+    ie: '10',
     safari: '12.1',
   },
   'es.string.trim-end': {


### PR DESCRIPTION
`String.prototype.trim()` is supported by IE10 or newer.

![trim on IE10](https://user-images.githubusercontent.com/86275/97995462-d1888200-1de6-11eb-9e4c-3db2b6463fb3.png)

See https://github.com/mdn/browser-compat-data/pull/7254 for MDN data related to this.