### PR TITLE
Bringing back support for Firefox (and other non-V8 browsers)

### DIFF
--- a/packages/core-js/internals/engine-v8-version.js
+++ b/packages/core-js/internals/engine-v8-version.js
@@ -17,4 +17,4 @@ if (v8) {
   }
 }
 
-module.exports = version && +version;
+module.exports = (version && +version) || 0;


### PR DESCRIPTION
This exported 'undefined' if the user agent/version didn't match, and for some reason beyond my understanding that value became `{default:undefined}` on import. While you can compare a literal object to a number, you cannot compare this special `{default:undefined}` object to a number, as you'd get a `TypeError` complaining about it. As more and more modules have been comparing known version numbers to the V8 version in order to prevent V8 deoptimization lately, these have started failing in Firefox (at least). All code I could find using this version number compares it in a way where '0' will be correctly evaluated as 'not one of those recent v8 versions we're guarding against', so it should work fine.

This might fix #764, but that issue has been fairly light on specific details, so maybe only time will tell if this fixes it. As described in that issue, I have been able to reproduce my specific issue as far back as 3.3.5.