### PR TITLE
use a smaller value for "length" when testing array "ToLength"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ jobs:
     name: tests
 
     strategy:
+      fail-fast: false
       matrix:
         os: [
           'ubuntu-latest',

--- a/packages/core-js/internals/array-last-index-of.js
+++ b/packages/core-js/internals/array-last-index-of.js
@@ -9,8 +9,7 @@ var min = Math.min;
 var nativeLastIndexOf = [].lastIndexOf;
 var NEGATIVE_ZERO = !!nativeLastIndexOf && 1 / [1].lastIndexOf(1, -0) < 0;
 var STRICT_METHOD = arrayMethodIsStrict('lastIndexOf');
-// For preventing possible almost infinite loop in non-standard implementations, test the forward version of the method
-var USES_TO_LENGTH = arrayMethodUsesToLength('indexOf', { ACCESSORS: true, 1: 0 });
+var USES_TO_LENGTH = arrayMethodUsesToLength('lastIndexOf', { ACCESSORS: true });
 var FORCED = NEGATIVE_ZERO || !STRICT_METHOD || !USES_TO_LENGTH;
 
 // `Array.prototype.lastIndexOf` method implementation

--- a/packages/core-js/internals/array-method-uses-to-length.js
+++ b/packages/core-js/internals/array-method-uses-to-length.js
@@ -12,16 +12,16 @@ module.exports = function (METHOD_NAME, options) {
   if (!options) options = {};
   var method = [][METHOD_NAME];
   var ACCESSORS = has(options, 'ACCESSORS') ? options.ACCESSORS : false;
-  var argument0 = has(options, 0) ? options[0] : thrower;
-  var argument1 = has(options, 1) ? options[1] : undefined;
+  var args = has(options, 0) ? [options[0]] : [thrower];
+  if (has(options, 1)) args.push(options[1]);
 
   return cache[METHOD_NAME] = !!method && !fails(function () {
     if (ACCESSORS && !DESCRIPTORS) return true;
-    var O = { length: -1 };
+    var O = { length: 10 };
 
     if (ACCESSORS) defineProperty(O, 1, { enumerable: true, get: thrower });
     else O[1] = 1;
 
-    method.call(O, argument0, argument1);
+    method.apply(O, args);
   });
 };

--- a/packages/core-js/modules/es.array.includes.js
+++ b/packages/core-js/modules/es.array.includes.js
@@ -4,7 +4,7 @@ var $includes = require('../internals/array-includes').includes;
 var addToUnscopables = require('../internals/add-to-unscopables');
 var arrayMethodUsesToLength = require('../internals/array-method-uses-to-length');
 
-var USES_TO_LENGTH = arrayMethodUsesToLength('indexOf', { ACCESSORS: true, 1: 0 });
+var USES_TO_LENGTH = arrayMethodUsesToLength('includes', { ACCESSORS: true });
 
 // `Array.prototype.includes` method
 // https://tc39.es/ecma262/#sec-array.prototype.includes

--- a/packages/core-js/modules/es.array.index-of.js
+++ b/packages/core-js/modules/es.array.index-of.js
@@ -8,7 +8,7 @@ var nativeIndexOf = [].indexOf;
 
 var NEGATIVE_ZERO = !!nativeIndexOf && 1 / [1].indexOf(1, -0) < 0;
 var STRICT_METHOD = arrayMethodIsStrict('indexOf');
-var USES_TO_LENGTH = arrayMethodUsesToLength('indexOf', { ACCESSORS: true, 1: 0 });
+var USES_TO_LENGTH = arrayMethodUsesToLength('indexOf', { ACCESSORS: true });
 
 // `Array.prototype.indexOf` method
 // https://tc39.es/ecma262/#sec-array.prototype.indexof

--- a/packages/core-js/modules/es.array.reduce-right.js
+++ b/packages/core-js/modules/es.array.reduce-right.js
@@ -7,8 +7,7 @@ var CHROME_VERSION = require('../internals/engine-v8-version');
 var IS_NODE = require('../internals/engine-is-node');
 
 var STRICT_METHOD = arrayMethodIsStrict('reduceRight');
-// For preventing possible almost infinite loop in non-standard implementations, test the forward version of the method
-var USES_TO_LENGTH = arrayMethodUsesToLength('reduce', { 1: 0 });
+var USES_TO_LENGTH = arrayMethodUsesToLength('reduceRight', { 1: 0 });
 // Chrome 80-82 has a critical bug
 // https://bugs.chromium.org/p/chromium/issues/detail?id=1049982
 var CHROME_BUG = !IS_NODE && CHROME_VERSION > 79 && CHROME_VERSION < 83;


### PR DESCRIPTION
Apologies if I don't understand why -1 was chosen in the first place, but I believe this change is appropriate. This bug is triggered when https://github.com/wkhtmltopdf/wkhtmltopdf (Qt Webkit) tries to load `packages/core-js/modules/es.array.splice.js` (it may also be triggered on `index-of.js`). It looks like how it handles `Object.defineProperty` does not interrupt execution and for splice it is trying to delete a ton of properties `[2..-1]` before eventually throwing (I believe it does actually throw, but it has to do a lot of work before getting to that point, shortening the array allows it to throw sooner).

Commit description:

Using the value -1 for the length of the object in the `arrayMethodUsesToLength` tests causes implementations to test against a very large "array". Use a smaller value to not cause those implementations to hang. This change allows all the uses of `arrayMethodUsesToLength` to use the actual function they are testing rather than a "proxy". In addition, change the testing function to use `apply` rather than `call` so that implementations that count the number of arguments will use the default values for any arguments that are optional rather than trying to interpret `undefined` incorrectly.