### PR TITLE
Fix crash in `NullProtoObjectViaIFrame()` on WSH

### DIFF
--- a/packages/core-js/internals/object-create.js
+++ b/packages/core-js/internals/object-create.js
@@ -33,14 +33,22 @@ var NullProtoObjectViaIFrame = function () {
   var iframe = documentCreateElement('iframe');
   var JS = 'java' + SCRIPT + ':';
   var iframeDocument;
-  iframe.style.display = 'none';
-  html.appendChild(iframe);
-  // https://github.com/zloirock/core-js/issues/475
-  iframe.src = String(JS);
-  iframeDocument = iframe.contentWindow.document;
-  iframeDocument.open();
-  iframeDocument.write(scriptTag('document.F=Object'));
-  iframeDocument.close();
+  if (iframe.style) {
+    iframe.style.display = 'none';
+    html.appendChild(iframe);
+    // https://github.com/zloirock/core-js/issues/475
+    iframe.src = String(JS);
+    iframeDocument = iframe.contentWindow.document;
+    iframeDocument.open();
+    iframeDocument.write(scriptTag('document.F=Object'));
+    iframeDocument.close();
+  } else {
+    /* global ActiveXObject -- in WSH */
+    activeXDocument = new ActiveXObject('htmlfile');  // without document.domain
+    iframeDocument = {
+      F: NullProtoObjectViaActiveX(activeXDocument)
+    };
+  }
   return iframeDocument.F;
 };
 


### PR DESCRIPTION
If you modify this part, it works well in WSH.

If `NullProtoObject()` fails, create an `htmlfile` object immediately without checking `document.domain`.