### PR TITLE
Fix microtasks on iOS Pebble

### DIFF
--- a/packages/core-js/internals/engine-is-ios-pebble.js
+++ b/packages/core-js/internals/engine-is-ios-pebble.js
@@ -1,0 +1,4 @@
+var userAgent = require('../internals/engine-user-agent');
+var global = require('../internals/global');
+
+module.exports = /iphone|ipod|ipad/i.test(userAgent) && global.Pebble !== undefined;

--- a/packages/core-js/internals/microtask.js
+++ b/packages/core-js/internals/microtask.js
@@ -2,6 +2,7 @@ var global = require('../internals/global');
 var getOwnPropertyDescriptor = require('../internals/object-get-own-property-descriptor').f;
 var macrotask = require('../internals/task').set;
 var IS_IOS = require('../internals/engine-is-ios');
+var IS_IOS_PEBBLE = require('../internals/engine-is-ios-pebble');
 var IS_WEBOS_WEBKIT = require('../internals/engine-is-webos-webkit');
 var IS_NODE = require('../internals/engine-is-node');
 
@@ -44,7 +45,7 @@ if (!queueMicrotask) {
       node.data = toggle = !toggle;
     };
   // environments with maybe non-completely correct, but existent Promise
-  } else if (Promise && Promise.resolve) {
+  } else if (!IS_IOS_PEBBLE && Promise && Promise.resolve) {
     // Promise.resolve without an argument throws an error in LG WebOS 2
     promise = Promise.resolve(undefined);
     // workaround of WebKit ~ iOS Safari 10.1 bug


### PR DESCRIPTION
The iOS Pebble app bundles its own copy of JavaScriptCore. This version includes a Promise constructor, but it's completely broken. The Promise polyfill detects this, but microtasks try to use it anyway.