### PR TITLE
BigInt support

### DIFF
--- a/packages/core-js/modules/es.array.at.js
+++ b/packages/core-js/modules/es.array.at.js
@@ -11,8 +11,8 @@ $({ target: 'Array', proto: true }, {
   at: function at(index) {
     var O = toObject(this);
     var len = toLength(O.length);
-    var relativeIndex = toInteger(index);
-    var k = relativeIndex >= 0 ? relativeIndex : len + relativeIndex;
+    var relativeIndex = toInteger(Number(index)); //Number() supports BigInt
+    var k = relativeIndex + (relativeIndex < 0 && len);
     return (k < 0 || k >= len) ? undefined : O[k];
   }
 });

--- a/packages/core-js/modules/es.array.at.js
+++ b/packages/core-js/modules/es.array.at.js
@@ -12,7 +12,7 @@ $({ target: 'Array', proto: true }, {
     var O = toObject(this);
     var len = toLength(O.length);
     var relativeIndex = toInteger(Number(index)); //Number() supports BigInt
-    var k = relativeIndex + (relativeIndex < 0 && len);
+    var k = relativeIndex + (relativeIndex < 0 ? len : 0);
     return (k < 0 || k >= len) ? undefined : O[k];
   }
 });


### PR DESCRIPTION
arr[n] where `arr` is an Array and `n` is a BigInt, is supported by Chromium. arr.at(n) throws an error because `toInteger` doesn't support BigInts