### PR TITLE
remove `forEach` from majority of DOM collection prototypes

### DIFF
--- a/packages/core-js/modules/web.dom-collections.for-each.js
+++ b/packages/core-js/modules/web.dom-collections.for-each.js
@@ -14,7 +14,9 @@ var handlePrototype = function (CollectionPrototype) {
 };
 
 for (var COLLECTION_NAME in DOMIterables) {
-  handlePrototype(global[COLLECTION_NAME] && global[COLLECTION_NAME].prototype);
+  if (DOMIterables[COLLECTION_NAME]) {
+    handlePrototype(global[COLLECTION_NAME] && global[COLLECTION_NAME].prototype);
+  }
 }
 
 handlePrototype(DOMTokenListPrototype);


### PR DESCRIPTION
Issue #988.

An alternative to this PR is to expand the compatibility test to include all the DOM Iterables.

I wasn't sure how you would want this change, so I have an simpler implementation [here](https://github.com/zloirock/core-js/commit/bd145f066acd096340a1361867935719d6e753e8).