### PR TITLE
Comprehensive function name lookup

### DIFF
--- a/packages/core-js/modules/es.function.name.js
+++ b/packages/core-js/modules/es.function.name.js
@@ -5,7 +5,7 @@ var defineProperty = require('../internals/object-define-property').f;
 
 var FunctionPrototype = Function.prototype;
 var functionToString = uncurryThis(FunctionPrototype.toString);
-var nameRE = /^\s*function ([^ (]*)/;
+var nameRE = /function\b(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\r\n]*[\r\n]+)*([^\s/(]*)/;
 var regExpExec = uncurryThis(nameRE.exec);
 var NAME = 'name';
 

--- a/packages/core-js/modules/es.function.name.js
+++ b/packages/core-js/modules/es.function.name.js
@@ -5,7 +5,7 @@ var defineProperty = require('../internals/object-define-property').f;
 
 var FunctionPrototype = Function.prototype;
 var functionToString = uncurryThis(FunctionPrototype.toString);
-var nameRE = /function\b(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\r\n]*[\r\n]+)*([^\s/(]*)/;
+var nameRE = /function\b(?:\s|\/\*[\S\s]*?\*\/|\/\/[^\n\r]*[\n\r]+)*([^\s(/]*)/;
 var regExpExec = uncurryThis(nameRE.exec);
 var NAME = 'name';
 

--- a/tests/tests/es.function.name.js
+++ b/tests/tests/es.function.name.js
@@ -20,5 +20,23 @@ if (DESCRIPTORS) {
       return '';
     };
     assert.same(baz.name, '');
+
+    assert.same(function /*
+    multi-line comment */() { /* empty */ }.name, '');
+
+    function /*
+    multi-line comment */
+    foobar() { /* empty */ }
+    assert.same(foobar.name, 'foobar');
+
+    function // simple-line comment
+    foobaz() { /* empty */ }
+    assert.same(foobaz.name, 'foobaz');
+
+    function // simple-line comment
+    /* multi-line comment */quux/*
+    multi-line comment
+    */() { /* empty */ }
+    assert.same(quux.name, 'quux');
   });
 }


### PR DESCRIPTION
Supports any of:
-- `function \s* name`
-- `function \s* /* multi-line comment */ \s* name`
-- `function \s* // single-line comment [\r\n]+ \s* name`