### PR TITLE
Fix comment of microtask for other environments

### DIFF
--- a/packages/core-js/internals/microtask.js
+++ b/packages/core-js/internals/microtask.js
@@ -63,7 +63,7 @@ if (!queueMicrotask) {
   // for other environments - macrotask based on:
   // - setImmediate
   // - MessageChannel
-  // - window.postMessag
+  // - window.postMessage
   // - onreadystatechange
   // - setTimeout
   } else {


### PR DESCRIPTION
Some functions provide macrotask API when the system does not support microtask, but one of them has the wrong name, it should be `window.postMessage` instead of `window.postMessag`, so I try to fix it.