### PR TITLE
fix: issue on uid library after consecutive optimizations

### DIFF
--- a/packages/core-js/internals/uid.js
+++ b/packages/core-js/internals/uid.js
@@ -1,9 +1,7 @@
-var uncurryThis = require('../internals/function-uncurry-this');
-
 var id = 0;
 var postfix = Math.random();
-var toString = uncurryThis(1.0.toString);
 
 module.exports = function (key) {
-  return 'Symbol(' + (key === undefined ? '' : key) + ')_' + toString(++id + postfix, 36);
+  var number = ++id + postfix;
+  return 'Symbol(' + (key === undefined ? '' : key) + ')_' + number.toString(36);
 };


### PR DESCRIPTION
Avoids the unusual syntax to get the Number.prototype.toString that might confuse code optimizers.

In our environment the line

`var toString = uncurryThis(1.0.toString);`

After optimizing the library during build, gets changed to 

`var toString = uncurryThis(1 .toString);`

Which is functionally identical, however our cloud provider once again minifies the code and removes the space

`var toString = uncurryThis(1.toString);`

Which is an invalid syntax. This pull requests tries to simplify the function to avoid this behavior on optimizers. This also helps in eliminating an import that was not needed. 
