### PR TITLE
Polyfill `Promise` with `unhandledrejection` event support (browser style) in Deno < 1.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 ##### Unreleased
-- Nothing
+- Polyfill `Promise` with `unhandledrejection` event support (browser style) in Deno < [1.24](https://github.com/denoland/deno/releases/tag/v1.24.0)
 
 ##### [3.23.5 - 2022.07.18](https://github.com/zloirock/core-js/releases/tag/v3.23.5)
 - Fixed a typo in the `structuredClone` feature detection, [#1106](https://github.com/zloirock/core-js/issues/1106)

--- a/packages/core-js-compat/src/data.mjs
+++ b/packages/core-js-compat/src/data.mjs
@@ -924,6 +924,8 @@ export const data = {
   'es.promise': {
     // V8 6.6 has a serious bug
     chrome: '67', // '51',
+    // `unhandledrejection` event support was added in Deno@1.24
+    deno: '1.24',
     firefox: '69',
     safari: '11.0',
     rhino: '1.7.14',
@@ -931,28 +933,38 @@ export const data = {
   'es.promise.constructor': {
     // V8 6.6 has a serious bug
     chrome: '67', // '51',
+    // `unhandledrejection` event support was added in Deno@1.24
+    deno: '1.24',
     firefox: '69',
     safari: '11.0',
     rhino: '1.7.14',
   },
   'es.promise.all': {
     chrome: '67',
+    // `unhandledrejection` event support was added in Deno@1.24
+    deno: '1.24',
     firefox: '69',
     safari: '11.0',
     rhino: '1.7.14',
   },
   'es.promise.all-settled': {
     chrome: '76',
+    // `unhandledrejection` event support was added in Deno@1.24
+    deno: '1.24',
     firefox: '71',
     safari: '13',
   },
   'es.promise.any': {
     chrome: '85',
+    // `unhandledrejection` event support was added in Deno@1.24
+    deno: '1.24',
     firefox: '79',
     safari: '14.0',
   },
   'es.promise.catch': {
     chrome: '67',
+    // `unhandledrejection` event support was added in Deno@1.24
+    deno: '1.24',
     firefox: '69',
     safari: '11.0',
     rhino: '1.7.14',
@@ -960,6 +972,8 @@ export const data = {
   'es.promise.finally': {
     // V8 6.6 has a serious bug
     chrome: '67', // '63',
+    // `unhandledrejection` event support was added in Deno@1.24
+    deno: '1.24',
     firefox: '69',
     // Previous versions are non-generic
     // https://bugs.webkit.org/show_bug.cgi?id=200788
@@ -969,18 +983,24 @@ export const data = {
   },
   'es.promise.race': {
     chrome: '67',
+    // `unhandledrejection` event support was added in Deno@1.24
+    deno: '1.24',
     firefox: '69',
     safari: '11.0',
     rhino: '1.7.14',
   },
   'es.promise.reject': {
     chrome: '67',
+    // `unhandledrejection` event support was added in Deno@1.24
+    deno: '1.24',
     firefox: '69',
     safari: '11.0',
     rhino: '1.7.14',
   },
   'es.promise.resolve': {
     chrome: '67',
+    // `unhandledrejection` event support was added in Deno@1.24
+    deno: '1.24',
     firefox: '69',
     safari: '11.0',
     rhino: '1.7.14',

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -33,6 +33,8 @@ if (!V8_VERSION && USERAGENT) {
 
 var IS_BROWSER = typeof window == 'object' && typeof Deno != 'object';
 
+var IS_DENO = typeof Deno == 'object' && Deno && typeof Deno.version == 'object';
+
 // var IS_NODE = Object.prototype.toString.call(process) == '[object process]';
 
 var WEBKIT_STRING_PAD_BUG = /Version\/10(?:\.\d+){1,2}(?: [\w./]+)?(?: Mobile\/\w+)? Safari\//.test(USERAGENT);
@@ -59,7 +61,7 @@ var PROMISES_SUPPORT = function () {
 
   return promise.then(empty) instanceof FakePromise
     && V8_VERSION !== 66
-    && (!IS_BROWSER || typeof PromiseRejectionEvent == 'function');
+    && (!(IS_BROWSER || IS_DENO) || typeof PromiseRejectionEvent == 'function');
 };
 
 var PROMISE_STATICS_ITERATION = function () {


### PR DESCRIPTION
https://github.com/denoland/deno/releases/tag/v1.24.0
https://github.com/mdn/browser-compat-data/pull/17054