### PR TITLE
Add `self`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Don't await non-objects returned from functions passed to `AsyncIterator` helpers, [proposal-iterator-helpers/239](https://github.com/tc39/proposal-iterator-helpers/pull/239)
   - `{ Iterator, AsyncIterator }.prototype.flatMap` supports returning both - iterables and iterators, [proposal-iterator-helpers/233](https://github.com/tc39/proposal-iterator-helpers/pull/233)
   - Early exit on broken `.next` in missed cases of `{ Iterator, AsyncIterator }.from`, [proposal-iterator-helpers/232](https://github.com/tc39/proposal-iterator-helpers/pull/232)
+- Added `self` polyfill as a part of [The Minimum Common Web Platform API](https://common-min-api.proposal.wintercg.org/), [specification](https://html.spec.whatwg.org/multipage/window-object.html#dom-self), [#1118](https://github.com/zloirock/core-js/issues/1118)
 - Added `inverse` option to `core-js-compat`, [#1119](https://github.com/zloirock/core-js/issues/1119)
 - Added `format` option to `core-js-builder`, [#1120](https://github.com/zloirock/core-js/issues/1120)
 - Added NodeJS 19.0 compat data

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ queueMicrotask(() => console.log('called as microtask'));
     - [Pre-stage 0 proposals](#pre-stage-0-proposals)
       - [`Reflect` metadata](#reflect-metadata)
   - [Web standards](#web-standards)
+    - [`self`](#self)
     - [`structuredClone`](#structuredclone)
     - [Base64 utility methods](#base64-utility-methods)
     - [`setTimeout` and `setInterval`](#settimeout-and-setinterval)
@@ -1831,7 +1832,7 @@ JSON.stringify({ '𠮷': ['\uDF06\uD834'] }); // => '{"𠮷":["\\udf06\\ud834"]}
 #### ECMAScript: globalThis[⬆](#index)
 Module [`es.global-this`](https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/es.global-this.js).
 ```js
-let globalThis: Object;
+let globalThis: GlobalThisValue;
 ```
 [*CommonJS entry points:*](#commonjs-api)
 ```js
@@ -3021,6 +3022,20 @@ Reflect.getOwnMetadata('foo', object); // => 'bar'
 ```
 
 ### Web standards[⬆](#index)
+#### `self`[⬆](#index)
+[Spec](https://html.spec.whatwg.org/multipage/window-object.html#dom-self), module [`web.self`](https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/web.self.js)
+```js
+getter self: GlobalThisValue;
+```
+[*CommonJS entry points:*](#commonjs-api)
+```js
+core-js(-pure)/stable|actual|full/self
+```
+[*Examples*](https://tinyurl.com/27nghouh):
+```js
+self.Array === Array; // => true
+```
+
 #### `structuredClone`[⬆](#index)
 [Spec](https://html.spec.whatwg.org/multipage/structured-data.html#dom-structuredclone), module [`web.structured-clone`](https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/web.structured-clone.js)
 ```js

--- a/packages/core-js-compat/src/data.mjs
+++ b/packages/core-js-compat/src/data.mjs
@@ -2520,6 +2520,15 @@ export const data = {
     node: '12.0', // '11.0',
     safari: '12.1',
   },
+  'web.self': {
+    chrome: '86',
+    // https://github.com/denoland/deno/issues/15765
+    // deno: false,
+    // fails in early Chrome-based Edge
+    // edge: '12',
+    firefox: '31',
+    safari: '10',
+  },
   'web.set-immediate': {
     bun: '0.1.7',
     ie: '10',

--- a/packages/core-js-compat/src/modules-by-versions.mjs
+++ b/packages/core-js-compat/src/modules-by-versions.mjs
@@ -160,5 +160,6 @@ export default {
   3.26: [
     'esnext.string.is-well-formed',
     'esnext.string.to-well-formed',
+    'web.self',
   ],
 };

--- a/packages/core-js-pure/override/modules/web.self.js
+++ b/packages/core-js-pure/override/modules/web.self.js
@@ -1,0 +1,8 @@
+var $ = require('../internals/export');
+var global = require('../internals/global');
+
+// `self` getter
+// https://html.spec.whatwg.org/multipage/window-object.html#dom-self
+$({ global: true, forced: global.self !== global }, {
+  self: global
+});

--- a/packages/core-js/actual/self.js
+++ b/packages/core-js/actual/self.js
@@ -1,0 +1,3 @@
+var parent = require('../stable/self');
+
+module.exports = parent;

--- a/packages/core-js/full/self.js
+++ b/packages/core-js/full/self.js
@@ -1,0 +1,3 @@
+var parent = require('../actual/self');
+
+module.exports = parent;

--- a/packages/core-js/modules/web.self.js
+++ b/packages/core-js/modules/web.self.js
@@ -1,0 +1,41 @@
+'use strict';
+var $ = require('../internals/export');
+var global = require('../internals/global');
+var defineBuiltInAccessor = require('../internals/define-built-in-accessor');
+var DESCRIPTORS = require('../internals/descriptors');
+
+var $TypeError = TypeError;
+// eslint-disable-next-line es/no-object-defineproperty -- safe
+var defineProperty = Object.defineProperty;
+var INCORRECT_VALUE = global.self !== global;
+
+// `self` getter
+// https://html.spec.whatwg.org/multipage/window-object.html#dom-self
+try {
+  if (DESCRIPTORS) {
+    // eslint-disable-next-line es/no-object-getownpropertydescriptor -- safe
+    var descriptor = Object.getOwnPropertyDescriptor(global, 'self');
+    // some engines have `self`, but with incorrect descriptor
+    // https://github.com/denoland/deno/issues/15765
+    if (INCORRECT_VALUE || !descriptor || !descriptor.get || !descriptor.enumerable) {
+      defineBuiltInAccessor(global, 'self', {
+        get: function self() {
+          return global;
+        },
+        set: function self(value) {
+          if (this !== global) throw $TypeError('Illegal invocation');
+          defineProperty(global, 'self', {
+            value: value,
+            writable: true,
+            configurable: true,
+            enumerable: true
+          });
+        },
+        configurable: true,
+        enumerable: true
+      });
+    }
+  } else $({ global: true, simple: true, forced: INCORRECT_VALUE }, {
+    self: global
+  });
+} catch (error) { /* empty */ }

--- a/packages/core-js/stable/self.js
+++ b/packages/core-js/stable/self.js
@@ -1,0 +1,4 @@
+require('../modules/web.self');
+var path = require('../internals/path');
+
+module.exports = path.self;

--- a/packages/core-js/web/index.js
+++ b/packages/core-js/web/index.js
@@ -7,6 +7,7 @@ require('../modules/web.dom-exception.stack');
 require('../modules/web.dom-exception.to-string-tag');
 require('../modules/web.immediate');
 require('../modules/web.queue-microtask');
+require('../modules/web.self');
 require('../modules/web.structured-clone');
 require('../modules/web.timers');
 require('../modules/web.url');

--- a/tests/commonjs.mjs
+++ b/tests/commonjs.mjs
@@ -584,6 +584,7 @@ for (PATH of ['core-js-pure', 'core-js']) {
     ok(typeof load(NS, 'dom-collections').iterator == 'function');
     ok(typeof load(NS, 'dom-collections/for-each') == 'function');
     ok(typeof load(NS, 'dom-collections/iterator') == 'function');
+    ok(load(NS, 'self').Math === Math);
     ok(typeof load(NS, 'set-timeout') == 'function');
     ok(typeof load(NS, 'set-interval') == 'function');
     ok(typeof load(NS, 'set-immediate') == 'function');

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -1853,6 +1853,13 @@ GLOBAL.tests = {
   'web.queue-microtask': function () {
     return Object.getOwnPropertyDescriptor(GLOBAL, 'queueMicrotask').value;
   },
+  'web.self': function () {
+    // eslint-disable-next-line no-restricted-globals -- safe
+    if (self !== GLOBAL) return false;
+    if (!DESCRIPTORS_SUPPORT) return true;
+    var descriptor = Object.getOwnPropertyDescriptor(GLOBAL, 'self');
+    return descriptor.get && descriptor.enumerable;
+  },
   'web.set-immediate': IMMEDIATE,
   'web.set-interval': TIMERS,
   'web.set-timeout': TIMERS,

--- a/tests/pure/web.self.js
+++ b/tests/pure/web.self.js
@@ -1,0 +1,6 @@
+import self from 'core-js-pure/stable/self';
+
+QUnit.test('self', assert => {
+  assert.same(self, Object(self), 'is object');
+  assert.same(self.Math, Math, 'contains globals');
+});

--- a/tests/tests/web.self.js
+++ b/tests/tests/web.self.js
@@ -1,0 +1,14 @@
+/* eslint-disable no-restricted-globals -- safe */
+import { DESCRIPTORS } from '../helpers/constants';
+
+QUnit.test('self', assert => {
+  assert.same(self, Object(self), 'is object');
+  assert.same(self.Math, Math, 'contains globals');
+  if (DESCRIPTORS) {
+    const descriptor = Object.getOwnPropertyDescriptor(self, 'self');
+    // can't be properly defined (non-configurable) in some ancient engines like PhantomJS
+    // assert.isFunction(descriptor.get, 'a getter');
+    // assert.true(descriptor.configurable, 'configurable');
+    assert.true(descriptor.enumerable, 'enumerable');
+  }
+});


### PR DESCRIPTION
The [Minimum Common Web Platform API](https://common-min-api.proposal.wintercg.org/) implies the presence of `self` in all web-interoperable runtimes.

By the [spec](https://html.spec.whatwg.org/multipage/window-object.html#dom-self), it should be a getter.

![image](https://user-images.githubusercontent.com/2213682/188729000-b520252f-489c-499a-a0be-e6d2c6c57133.png)

However, some old and even actual environments add it as a usual property.

https://github.com/denoland/deno/issues/15765

Initially, I was skeptical about the compatibility of this with NodeJS, however, exploring GitHub shows that detection of missed `self` is usually used only in testing environments or in complex with other methods and `self` is polyfilled too often.

https://github.com/wintercg/proposal-common-minimum-api/issues/28

Thoughts?