### PR TITLE
Add `inverse` option to `core-js-compat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 ##### Unreleased
-- Nothing
+- Added `inverse` option to `core-js-compat`, [#1119](https://github.com/zloirock/core-js/issues/1119)
 
 ##### [3.25.5 - 2022.10.04](https://github.com/zloirock/core-js/releases/tag/v3.25.5)
 - Fixed regression with an error on reuse of some built-in methods from another realm, [#1133](https://github.com/zloirock/core-js/issues/1133)

--- a/packages/core-js-compat/README.md
+++ b/packages/core-js-compat/README.md
@@ -12,19 +12,20 @@
 import compat from 'core-js-compat';
 
 const {
-  list,                         // array of required modules
-  targets,                      // object with targets for each module
+  list,                       // array of required modules
+  targets,                    // object with targets for each module
 } = compat({
-  targets: '> 1%',              // browserslist query or object of minimum environment versions to support, see below
-  modules: [                    // optional list / filter of modules - regex, sting or an array of them:
-    'core-js/actual',           // - an entry point
-    'esnext.array.unique-by',   // - a module name (or just a start of a module name)
-    /^web\./,                   // - regex that a module name must satisfy
+  targets: '> 1%',            // browserslist query or object of minimum environment versions to support, see below
+  modules: [                  // optional list / filter of modules - regex, sting or an array of them:
+    'core-js/actual',         // - an entry point
+    'esnext.array.unique-by', // - a module name (or just a start of a module name)
+    /^web\./,                 // - regex that a module name must satisfy
   ],
-  exclude: [                    // optional list / filter of modules to exclude, the signature is similar to `modules` option
+  exclude: [                  // optional list / filter of modules to exclude, the signature is similar to `modules` option
     'web.atob',
   ],
-  version: '3.25',              // used `core-js` version, by default - the latest
+  version: '3.25',            // used `core-js` version, by default - the latest
+  inverse: false,             // inverse of the result - shows modules that are NOT required for the target environment
 });
 
 console.log(targets);

--- a/packages/core-js-compat/compat.js
+++ b/packages/core-js-compat/compat.js
@@ -54,8 +54,10 @@ module.exports = function ({
   exclude = [],
   targets = null,
   version = null,
+  inverse = false,
 } = {}) {
   if (modules == null) modules = filter;
+  inverse = !!inverse;
 
   const parsedTargets = targets ? targetsParser(targets) : null;
 
@@ -72,12 +74,12 @@ module.exports = function ({
 
   modules = intersection(modules, version ? getModulesListForTargetVersion(version) : allModules);
 
-  modules = filterOutStabilizedProposals(modules);
+  if (!inverse) modules = filterOutStabilizedProposals(modules);
 
   for (const key of modules) {
     const check = checkModule(key, parsedTargets);
 
-    if (check.required) {
+    if (check.required ^ inverse) {
       result.list.push(key);
       result.targets[key] = check.targets;
     }

--- a/tests/compat-tools/compat.mjs
+++ b/tests/compat-tools/compat.mjs
@@ -1,4 +1,4 @@
-import { deepEqual } from 'assert/strict';
+import { deepEqual, ok } from 'assert/strict';
 import compat from 'core-js-compat/compat.js';
 
 deepEqual(compat({
@@ -118,5 +118,16 @@ deepEqual(compat({
     'es.math.to-string-tag': { chrome: '40', firefox: '27' },
   },
 }, 'some targets');
+
+const { list: inverted1 } = compat({ targets: { esmodules: true }, inverse: true });
+
+ok(inverted1.includes('es.symbol.iterator'), 'inverse #1');
+ok(!inverted1.includes('esnext.iterator.from'), 'inverse #2');
+ok(!inverted1.includes('esnext.array.at'), 'inverse #3');
+
+const { list: inverted2 } = compat({ modules: 'core-js/es/math', targets: { esmodules: true }, inverse: true });
+
+ok(inverted2.includes('es.math.acosh'), 'inverse #4');
+ok(!inverted2.includes('es.map'), 'inverse #5');
 
 echo(chalk.green('compat tool tested'));


### PR DESCRIPTION
For example, what modules are NOT required for the `esmodules` target?

```js
import compat from 'core-js-compat';

const { list } = compat({ targets: { esmodules: true }, inverse: true });
/* =>
[
  "es.symbol",
  "es.symbol.has-instance",
  "es.symbol.is-concat-spreadable",
  "es.symbol.iterator",
  "es.symbol.species",
  "es.symbol.to-primitive",
  "es.symbol.to-string-tag",
  "es.symbol.unscopables",
  "es.error.to-string",
  "es.array.concat",
  "es.array.copy-within",
  "es.array.every",
  "es.array.fill",
  "es.array.filter",
  "es.array.find",
  "es.array.find-index",
  "es.array.for-each",
  "es.array.from",
  "es.array.index-of",
  "es.array.is-array",
  "es.array.join",
  "es.array.last-index-of",
  "es.array.map",
  "es.array.of",
  "es.array.slice",
  "es.array.some",
  "es.array.species",
  "es.array.splice",
  "es.array-buffer.is-view",
  "es.data-view",
  "es.date.get-year",
  "es.date.now",
  "es.date.set-year",
  "es.date.to-gmt-string",
  "es.date.to-iso-string",
  "es.date.to-json",
  "es.date.to-primitive",
  "es.date.to-string",
  "es.escape",
  "es.function.bind",
  "es.function.has-instance",
  "es.function.name",
  "es.json.to-string-tag",
  "es.map",
  "es.math.acosh",
  "es.math.asinh",
  "es.math.atanh",
  "es.math.cbrt",
  "es.math.clz32",
  "es.math.cosh",
  "es.math.expm1",
  "es.math.fround",
  "es.math.imul",
  "es.math.log10",
  "es.math.log1p",
  "es.math.log2",
  "es.math.sign",
  "es.math.sinh",
  "es.math.tanh",
  "es.math.to-string-tag",
  "es.math.trunc",
  "es.number.constructor",
  "es.number.epsilon",
  "es.number.is-finite",
  "es.number.is-integer",
  "es.number.is-nan",
  "es.number.is-safe-integer",
  "es.number.max-safe-integer",
  "es.number.min-safe-integer",
  "es.number.to-precision",
  "es.object.create",
  "es.object.define-properties",
  "es.object.define-property",
  "es.object.entries",
  "es.object.freeze",
  "es.object.get-own-property-descriptor",
  "es.object.get-own-property-descriptors",
  "es.object.get-own-property-names",
  "es.object.get-prototype-of",
  "es.object.is",
  "es.object.is-extensible",
  "es.object.is-frozen",
  "es.object.is-sealed",
  "es.object.keys",
  "es.object.prevent-extensions",
  "es.object.seal",
  "es.object.set-prototype-of",
  "es.object.to-string",
  "es.object.values",
  "es.reflect.apply",
  "es.reflect.construct",
  "es.reflect.define-property",
  "es.reflect.delete-property",
  "es.reflect.get",
  "es.reflect.get-own-property-descriptor",
  "es.reflect.get-prototype-of",
  "es.reflect.has",
  "es.reflect.is-extensible",
  "es.reflect.own-keys",
  "es.reflect.prevent-extensions",
  "es.reflect.set-prototype-of",
  "es.regexp.sticky",
  "es.set",
  "es.string.code-point-at",
  "es.string.from-code-point",
  "es.string.iterator",
  "es.string.raw",
  "es.string.repeat",
  "es.string.substr",
  "es.string.anchor",
  "es.string.big",
  "es.string.blink",
  "es.string.bold",
  "es.string.fixed",
  "es.string.fontcolor",
  "es.string.fontsize",
  "es.string.italics",
  "es.string.link",
  "es.string.small",
  "es.string.strike",
  "es.string.sub",
  "es.string.sup",
  "es.typed-array.copy-within",
  "es.typed-array.every",
  "es.typed-array.filter",
  "es.typed-array.find",
  "es.typed-array.find-index",
  "es.typed-array.for-each",
  "es.typed-array.includes",
  "es.typed-array.index-of",
  "es.typed-array.iterator",
  "es.typed-array.join",
  "es.typed-array.last-index-of",
  "es.typed-array.map",
  "es.typed-array.reduce",
  "es.typed-array.reduce-right",
  "es.typed-array.reverse",
  "es.typed-array.slice",
  "es.typed-array.some",
  "es.typed-array.subarray",
  "es.typed-array.to-string",
  "es.unescape",
  "es.weak-map",
  "es.weak-set",
  "web.dom-collections.for-each",
  "web.timers"
]
*/
```