### PR TITLE
Update `Array.fromAsync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ##### Unreleased
+- Avoiding observable side effects of `%Array.prototype.values%` usage in array-like branch of `Array.fromAsync`, [proposal-array-from-async/30](https://github.com/tc39/proposal-array-from-async/pull/30)
 - Added `inverse` option to `core-js-compat`, [#1119](https://github.com/zloirock/core-js/issues/1119)
 - Added `format` option to `core-js-builder`, [#1120](https://github.com/zloirock/core-js/issues/1120)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Changelog
 ##### Unreleased
-- Avoiding observable side effects of `%Array.prototype.values%` usage in array-like branch of `Array.fromAsync`, [proposal-array-from-async/30](https://github.com/tc39/proposal-array-from-async/pull/30)
+- [`Array.fromAsync` proposal](https://github.com/tc39/proposal-array-from-async):
+  - Moved to Stage 3, [September TC39 meeting](https://github.com/babel/proposals/issues/83#issuecomment-1246218703)
+  - Avoid observable side effects of `%Array.prototype.values%` usage in array-like branch, [proposal-array-from-async/30](https://github.com/tc39/proposal-array-from-async/pull/30)
 - Added `inverse` option to `core-js-compat`, [#1119](https://github.com/zloirock/core-js/issues/1119)
 - Added `format` option to `core-js-builder`, [#1120](https://github.com/zloirock/core-js/issues/1120)
 

--- a/README.md
+++ b/README.md
@@ -126,13 +126,13 @@ queueMicrotask(() => console.log('called as microtask'));
       - [`Symbol.prototype.description`](#symbolprototypedescription)
       - [Well-formed `JSON.stringify`](#well-formed-jsonstringify)
     - [Stage 3 proposals](#stage-3-proposals)
+      - [`Array.fromAsync`](#arrayfromasync)
       - [`Array` grouping](#array-grouping)
       - [Change `Array` by copy](#change-array-by-copy)
     - [Stage 2 proposals](#stage-2-proposals)
       - [`Iterator` helpers](#iterator-helpers)
       - [New `Set` methods](#new-set-methods)
       - [`Map.prototype.emplace`](#mapprototypeemplace)
-      - [`Array.fromAsync`](#arrayfromasync)
       - [`Array.isTemplateObject`](#arrayistemplateobject)
       - [`Symbol.{ asyncDispose, dispose }` for `using` statement](#symbol-asyncdispose-dispose--for-using-statement)
       - [`Symbol.metadataKey` for decorators metadata proposal](#symbolmetadatakey-for-decorators-metadata-proposal)
@@ -2103,6 +2103,22 @@ core-js/proposals/well-formed-stringify
 ```js
 core-js(-pure)/stage/3
 ```
+##### [`Array.fromAsync`](https://github.com/tc39/proposal-array-from-async)[⬆](#index)
+Modules [`esnext.array.from-async`](https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/esnext.array.from-async.js).
+```js
+class Array {
+  static fromAsync(asyncItems: AsyncIterable | Iterable | ArrayLike, mapfn?: (value: any, index: number) => any, thisArg?: any): Array;
+}
+```
+[*CommonJS entry points:*](#commonjs-api)
+```js
+core-js/proposals/array-from-async-stage-2
+core-js(-pure)/full/array/from-async
+```
+[*Example*](https://goo.gl/Jt7SsD):
+```js
+await Array.fromAsync((async function * (){ yield * [1, 2, 3] })(), i => i * i); // => [1, 4, 9]
+```
 ##### [`Array` grouping](https://github.com/tc39/proposal-array-grouping)[⬆](#index)
 Modules [`esnext.array.group`](https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/esnext.array.group.js), [`esnext.array.group-to-map`](https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/esnext.array.group-to-map.js).
 ```js
@@ -2342,22 +2358,6 @@ map.emplace('a', { update: it => it ** 2, insert: () => 3}); // => 4
 map.emplace('b', { update: it => it ** 2, insert: () => 3}); // => 3
 
 console.log(map); // => Map { 'a': 4, 'b': 3 }
-```
-##### [`Array.fromAsync`](https://github.com/tc39/proposal-array-from-async)[⬆](#index)
-Modules [`esnext.array.from-async`](https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/esnext.array.from-async.js).
-```js
-class Array {
-  static fromAsync(asyncItems: AsyncIterable | Iterable | ArrayLike, mapfn?: (value: any, index: number) => any, thisArg?: any): Array;
-}
-```
-[*CommonJS entry points:*](#commonjs-api)
-```js
-core-js/proposals/array-from-async-stage-2
-core-js(-pure)/full/array/from-async
-```
-[*Example*](https://goo.gl/Jt7SsD):
-```js
-await Array.fromAsync((async function * (){ yield * [1, 2, 3] })(), i => i * i); // => [1, 4, 9]
 ```
 ##### [`Array.isTemplateObject`](https://github.com/tc39/proposal-array-is-template-object)[⬆](#index)
 Module [`esnext.array.is-template-object`](https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/esnext.array.is-template-object.js)

--- a/packages/core-js/actual/array/from-async.js
+++ b/packages/core-js/actual/array/from-async.js
@@ -1,0 +1,8 @@
+require('../../modules/es.array.iterator');
+require('../../modules/es.object.to-string');
+require('../../modules/es.promise');
+require('../../modules/es.string.iterator');
+require('../../modules/esnext.array.from-async');
+var path = require('../../internals/path');
+
+module.exports = path.Array.fromAsync;

--- a/packages/core-js/actual/array/index.js
+++ b/packages/core-js/actual/array/index.js
@@ -3,6 +3,7 @@ require('../../modules/es.map');
 require('../../modules/es.object.to-string');
 require('../../modules/esnext.array.find-last');
 require('../../modules/esnext.array.find-last-index');
+require('../../modules/esnext.array.from-async');
 require('../../modules/esnext.array.group');
 require('../../modules/esnext.array.group-by');
 require('../../modules/esnext.array.group-by-to-map');

--- a/packages/core-js/full/array/from-async.js
+++ b/packages/core-js/full/array/from-async.js
@@ -1,8 +1,3 @@
-require('../../modules/es.array.iterator');
-require('../../modules/es.object.to-string');
-require('../../modules/es.promise');
-require('../../modules/es.string.iterator');
-require('../../modules/esnext.array.from-async');
-var path = require('../../internals/path');
+var parent = require('../../actual/array/from-async');
 
-module.exports = path.Array.fromAsync;
+module.exports = parent;

--- a/packages/core-js/full/array/index.js
+++ b/packages/core-js/full/array/index.js
@@ -1,6 +1,5 @@
 var parent = require('../../actual/array');
 require('../../modules/es.promise');
-require('../../modules/esnext.array.from-async');
 // TODO: Remove from `core-js@4`
 require('../../modules/esnext.array.at');
 // TODO: Remove from `core-js@4`

--- a/packages/core-js/stage/2.js
+++ b/packages/core-js/stage/2.js
@@ -1,4 +1,3 @@
-require('../proposals/array-from-async-stage-2');
 require('../proposals/array-is-template-object');
 require('../proposals/decorator-metadata');
 require('../proposals/iterator-helpers');

--- a/packages/core-js/stage/3.js
+++ b/packages/core-js/stage/3.js
@@ -1,3 +1,4 @@
+require('../proposals/array-from-async-stage-2');
 require('../proposals/array-grouping-stage-3-2');
 require('../proposals/change-array-by-copy');
 // TODO: Obsolete versions, remove from `core-js@4`

--- a/tests/commonjs.mjs
+++ b/tests/commonjs.mjs
@@ -596,6 +596,7 @@ for (PATH of ['core-js-pure', 'core-js']) {
   }
 
   for (const NS of ['actual', 'full', 'features']) {
+    ok(typeof load(NS, 'array/from-async') == 'function');
     ok(typeof load(NS, 'array/group') == 'function');
     ok(typeof load(NS, 'array/group-to-map') == 'function');
     ok(typeof load(NS, 'array/group-by') == 'function');
@@ -667,7 +668,6 @@ for (PATH of ['core-js-pure', 'core-js']) {
     const Set = load(NS, 'set');
     const WeakMap = load(NS, 'weak-map');
     const WeakSet = load(NS, 'weak-set');
-    ok(typeof load(NS, 'array/from-async') == 'function');
     ok(typeof load(NS, 'array/filter-out') == 'function');
     ok(typeof load(NS, 'array/filter-reject') == 'function');
     ok(typeof load(NS, 'array/is-template-object') == 'function');


### PR DESCRIPTION
- Moved to Stage 3, [September TC39 meeting](https://github.com/babel/proposals/issues/83#issuecomment-1246218703)
- Avoid observable side effects of `%Array.prototype.values%` usage in array-like branch, [proposal-array-from-async/30](https://github.com/tc39/proposal-array-from-async/pull/30)