### PR TITLE
Rename `Function.prototype.unThis` Stage 0 proposal and method to `Function.prototype.demethodize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed [Safari `String.prototype.toWellFormed` `ToString` conversion bug](https://bugs.webkit.org/show_bug.cgi?id=251757)
 - Simplified internal behaviour of `{ AsyncDisposableStack, DisposableStack }.prototype.use`, [proposal-explicit-resource-management/143](https://github.com/tc39/proposal-explicit-resource-management/pull/143)
 - `InstallErrorCause` removed from `SuppressedError`, [January 2023 TC39 meeting](https://github.com/babel/proposals/issues/86#issuecomment-1410889704), [proposal-explicit-resource-management/145](https://github.com/tc39/proposal-explicit-resource-management/pull/146)
+- `Function.prototype.unThis` Stage 0 proposal and method [renamed to `Function.prototype.demethodize`](https://github.com/js-choi/proposal-function-demethodize)
 - Improved some cases handling of array-replacer in `JSON.stringify` symbols handling fix
 - Fixed configurability and `ToString` conversion of some accessors
 - Added Opera Android 73 compat data mapping

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ structuredClone(new Set([1, 2, 3])); // => new Set([1, 2, 3])
       - [`String.prototype.codePoints`](#stringprototypecodepoints)
       - [`Symbol.matcher` for pattern matching](#symbolmatcher-for-pattern-matching)
     - [Stage 0 proposals](#stage-0-proposals)
-      - [`Function.prototype.unThis`](#functionprototypeunthis)
+      - [`Function.prototype.demethodize`](#functionprototypedemethodize)
       - [`Function.{ isCallable, isConstructor }`](#function-iscallable-isconstructor-)
       - [`URL`](#url)
     - [Pre-stage 0 proposals](#pre-stage-0-proposals)
@@ -2898,22 +2898,22 @@ core-js(-pure)/full/symbol/matcher
 ```js
 core-js(-pure)/stage/0
 ```
-##### [`Function.prototype.unThis`](https://github.com/js-choi/proposal-function-un-this)[⬆](#index)
-Module [`esnext.function.un-this`](https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/esnext.function.un-this.js)
+##### [`Function.prototype.demethodize`](https://github.com/js-choi/proposal-function-demethodize)[⬆](#index)
+Module [`esnext.function.demethodize`](https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/esnext.function.demethodize.js)
 ```js
 class Function {
-  unThis(): Function;
+  demethodize(): Function;
 }
 ```
 [*CommonJS entry points:*](#commonjs-api)
 ```
-core-js/proposals/function-un-this
-core-js(-pure)/full/function/un-this
-core-js(-pure)/full/function/virtual/un-this
+core-js/proposals/function-demethodize
+core-js(-pure)/full/function/demethodize
+core-js(-pure)/full/function/virtual/demethodize
 ```
-[*Examples*](https://is.gd/t1Bvhn):
+[*Examples*](https://tinyurl.com/2ltmohgl):
 ```js
-const slice = Array.prototype.slice.unThis();
+const slice = Array.prototype.slice.demethodize();
 
 slice([1, 2, 3], 1); // => [2, 3]
 ```

--- a/packages/core-js-compat/src/data.mjs
+++ b/packages/core-js-compat/src/data.mjs
@@ -1936,10 +1936,13 @@ export const data = {
   },
   'esnext.disposable-stack.constructor': {
   },
+  'esnext.function.demethodize': {
+  },
   'esnext.function.is-callable': {
   },
   'esnext.function.is-constructor': {
   },
+  // TODO: Remove from `core-js@4`
   'esnext.function.un-this': {
   },
   // TODO: Remove from `core-js@4`

--- a/packages/core-js-compat/src/modules-by-versions.mjs
+++ b/packages/core-js-compat/src/modules-by-versions.mjs
@@ -185,5 +185,6 @@ export default {
     'es.typed-array.to-reversed',
     'es.typed-array.to-sorted',
     'es.typed-array.with',
+    'esnext.function.demethodize',
   ],
 };

--- a/packages/core-js/full/function/demethodize.js
+++ b/packages/core-js/full/function/demethodize.js
@@ -1,0 +1,4 @@
+require('../../modules/esnext.function.demethodize');
+var entryUnbind = require('../../internals/entry-unbind');
+
+module.exports = entryUnbind('Function', 'demethodize');

--- a/packages/core-js/full/function/index.js
+++ b/packages/core-js/full/function/index.js
@@ -1,6 +1,8 @@
 var parent = require('../../actual/function');
+require('../../modules/esnext.function.demethodize');
 require('../../modules/esnext.function.is-callable');
 require('../../modules/esnext.function.is-constructor');
+// TODO: Remove from `core-js@4`
 require('../../modules/esnext.function.un-this');
 
 module.exports = parent;

--- a/packages/core-js/full/function/virtual/demethodize.js
+++ b/packages/core-js/full/function/virtual/demethodize.js
@@ -1,0 +1,4 @@
+require('../../../modules/esnext.function.demethodize');
+var entryVirtual = require('../../../internals/entry-virtual');
+
+module.exports = entryVirtual('Function').demethodize;

--- a/packages/core-js/full/function/virtual/index.js
+++ b/packages/core-js/full/function/virtual/index.js
@@ -1,4 +1,6 @@
 var parent = require('../../../actual/function/virtual');
+require('../../../modules/esnext.function.demethodize');
+// TODO: Remove from `core-js@4`
 require('../../../modules/esnext.function.un-this');
 
 module.exports = parent;

--- a/packages/core-js/full/instance/demethodize.js
+++ b/packages/core-js/full/instance/demethodize.js
@@ -1,0 +1,9 @@
+var isPrototypeOf = require('../../internals/object-is-prototype-of');
+var method = require('../function/virtual/demethodize');
+
+var FunctionPrototype = Function.prototype;
+
+module.exports = function (it) {
+  var own = it.demethodize;
+  return it === FunctionPrototype || (isPrototypeOf(FunctionPrototype, it) && own === FunctionPrototype.demethodize) ? method : own;
+};

--- a/packages/core-js/internals/function-demethodize.js
+++ b/packages/core-js/internals/function-demethodize.js
@@ -1,0 +1,7 @@
+'use strict';
+var uncurryThis = require('../internals/function-uncurry-this');
+var aCallable = require('../internals/a-callable');
+
+module.exports = function demethodize() {
+  return uncurryThis(aCallable(this));
+};

--- a/packages/core-js/modules/esnext.function.demethodize.js
+++ b/packages/core-js/modules/esnext.function.demethodize.js
@@ -1,9 +1,8 @@
 var $ = require('../internals/export');
 var demethodize = require('../internals/function-demethodize');
 
-// `Function.prototype.unThis` method
+// `Function.prototype.demethodize` method
 // https://github.com/js-choi/proposal-function-demethodize
-// TODO: Remove from `core-js@4`
-$({ target: 'Function', proto: true, forced: true, name: 'demethodize' }, {
-  unThis: demethodize
+$({ target: 'Function', proto: true, forced: true }, {
+  demethodize: demethodize
 });

--- a/packages/core-js/proposals/function-demethodize.js
+++ b/packages/core-js/proposals/function-demethodize.js
@@ -1,0 +1,2 @@
+// https://github.com/js-choi/proposal-function-demethodize
+require('../modules/esnext.function.demethodize');

--- a/packages/core-js/proposals/function-un-this.js
+++ b/packages/core-js/proposals/function-un-this.js
@@ -1,2 +1,3 @@
+// TODO: Remove from `core-js@4`
 // https://github.com/js-choi/proposal-function-un-this
 require('../modules/esnext.function.un-this');

--- a/packages/core-js/stage/0.js
+++ b/packages/core-js/stage/0.js
@@ -1,11 +1,12 @@
 var parent = require('./1');
 
 require('../proposals/efficient-64-bit-arithmetic');
+require('../proposals/function-demethodize');
 require('../proposals/function-is-callable-is-constructor');
-require('../proposals/function-un-this');
 require('../proposals/string-at');
 require('../proposals/url');
 // TODO: Obsolete versions, remove from `core-js@4`:
 require('../proposals/array-filtering');
+require('../proposals/function-un-this');
 
 module.exports = parent;

--- a/tests/compat-data/tests-coverage.mjs
+++ b/tests/compat-data/tests-coverage.mjs
@@ -22,6 +22,7 @@ const ignore = new Set([
   'esnext.array.last-index',
   'esnext.array.last-item',
   'esnext.async-iterator.as-indexed-pairs',
+  'esnext.function.un-this',
   'esnext.iterator.as-indexed-pairs',
   'esnext.map.update-or-insert',
   'esnext.map.upsert',

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -1517,14 +1517,14 @@ GLOBAL.tests = {
   'esnext.disposable-stack.constructor': function () {
     return typeof DisposableStack == 'function';
   },
+  'esnext.function.demethodize': function () {
+    return Function.prototype.demethodize;
+  },
   'esnext.function.is-callable': function () {
     return Function.isCallable;
   },
   'esnext.function.is-constructor': function () {
     return Function.isConstructor;
-  },
-  'esnext.function.un-this': function () {
-    return Function.prototype.unThis;
   },
   'esnext.iterator.constructor': function () {
     try {

--- a/tests/entries/unit.mjs
+++ b/tests/entries/unit.mjs
@@ -739,6 +739,8 @@ for (PATH of ['core-js-pure', 'core-js']) {
     load(NS, 'bigint');
     ok(typeof load(NS, 'composite-key')({}, 1, {}) === 'object');
     ok(typeof load(NS, 'composite-symbol')({}, 1, {}) === 'symbol');
+    ok(load(NS, 'function/demethodize')([].slice)([1, 2, 3], 1)[0] === 2);
+    ok(load(NS, 'function/virtual/demethodize').call([].slice)([1, 2, 3], 1)[0] === 2);
     ok(!load(NS, 'function/is-callable')(class { /* empty */ }));
     ok(!load(NS, 'function/is-constructor')(it => it));
     ok(load(NS, 'function/un-this')([].slice)([1, 2, 3], 1)[0] === 2);
@@ -837,6 +839,12 @@ for (PATH of ['core-js-pure', 'core-js']) {
     ok(typeof instanceCodePoints('') == 'function');
     ok(instanceCodePoints('').call('abc').next().value.codePoint === 97);
 
+    const instanceDemethodize = load(NS, 'instance/demethodize');
+    ok(typeof instanceDemethodize == 'function');
+    ok(instanceDemethodize({}) === undefined);
+    ok(typeof instanceDemethodize([].slice) == 'function');
+    ok(instanceDemethodize([].slice).call([].slice)([1, 2, 3], 1)[0] === 2);
+
     const instanceFilterOut = load(NS, 'instance/filter-out');
     ok(typeof instanceFilterOut == 'function');
     ok(instanceFilterOut({}) === undefined);
@@ -888,6 +896,7 @@ for (PATH of ['core-js-pure', 'core-js']) {
   load('proposals/efficient-64-bit-arithmetic');
   load('proposals/error-cause');
   load('proposals/explicit-resource-management');
+  load('proposals/function-demethodize');
   load('proposals/function-is-callable-is-constructor');
   load('proposals/function-un-this');
   load('proposals/global-this');

--- a/tests/unit-global/esnext.function.demethodize.js
+++ b/tests/unit-global/esnext.function.demethodize.js
@@ -1,0 +1,10 @@
+QUnit.test('Function#demethodize', assert => {
+  const { demethodize } = Function.prototype;
+  assert.isFunction(demethodize);
+  assert.arity(demethodize, 0);
+  assert.name(demethodize, 'demethodize');
+  assert.looksNative(demethodize);
+  assert.nonEnumerable(Function.prototype, 'demethodize');
+  assert.same(function () { return 42; }.demethodize()(), 42);
+  assert.deepEqual(Array.prototype.slice.demethodize()([1, 2, 3], 1), [2, 3]);
+});

--- a/tests/unit-global/esnext.function.un-this.js
+++ b/tests/unit-global/esnext.function.un-this.js
@@ -2,7 +2,7 @@ QUnit.test('Function#unThis', assert => {
   const { unThis } = Function.prototype;
   assert.isFunction(unThis);
   assert.arity(unThis, 0);
-  assert.name(unThis, 'unThis');
+  // assert.name(unThis, 'unThis');
   assert.looksNative(unThis);
   assert.nonEnumerable(Function.prototype, 'unThis');
   assert.same(function () { return 42; }.unThis()(), 42);

--- a/tests/unit-pure/esnext.function.demethodize.js
+++ b/tests/unit-pure/esnext.function.demethodize.js
@@ -1,0 +1,8 @@
+import demethodize from 'core-js-pure/full/function/demethodize';
+
+QUnit.test('Function#demethodize', assert => {
+  assert.isFunction(demethodize);
+  // eslint-disable-next-line prefer-arrow-callback -- required for testing
+  assert.same(demethodize(function () { return 42; })(), 42);
+  assert.deepEqual(demethodize(Array.prototype.slice)([1, 2, 3], 1), [2, 3]);
+});


### PR DESCRIPTION
It was renamed a long time ago, I wanted to wait when those changes will be present to TC39. However, since it's not present for a long time, it's better to rename it to avoid confusion.