### PR TITLE
core-js-builder: Allow webpack 5 and modernize code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   - Added Electron 25 and updated 24 compat data mapping
   - Added Quest Browser 26 compat data mapping
   - Updated Opera Android 74 compat data
+- `core-js-builder`
+  - Webpack dependency now allows to use webpack 5
+  - Increase minimum node version to 12.x and modernized code
 
 ##### [3.29.1 - 2023.03.13](https://github.com/zloirock/core-js/releases/tag/v3.29.1)
 - Fixed dependencies of some entries

--- a/packages/core-js-builder/index.js
+++ b/packages/core-js-builder/index.js
@@ -1,18 +1,12 @@
 'use strict';
 /* eslint-disable no-console -- output */
 const { promisify } = require('util');
-const fs = require('fs');
-// TODO: replace by `fs.promises` after dropping NodeJS < 10 support
-const readFile = promisify(fs.readFile);
-const unlink = promisify(fs.unlink);
-const writeFile = promisify(fs.writeFile);
 const { dirname, join } = require('path');
+const { banner } = require('./config');
 const tmpdir = require('os').tmpdir();
-// TODO: replace by `mkdir` with `recursive: true` after dropping NodeJS < 10.12 support
-const mkdirp = promisify(require('mkdirp'));
 const webpack = promisify(require('webpack'));
 const compat = require('core-js-compat/compat');
-const { banner } = require('./config');
+const { mkdir, readFile, unlink, writeFile} = require('fs').promises;
 
 function normalizeSummary(unit = {}) {
   let size, modules;
@@ -96,7 +90,7 @@ module.exports = async function ({
   }
 
   if (filename != null) {
-    await mkdirp(dirname(filename));
+    await mkdir(dirname(filename), { recursive: true });
     await writeFile(filename, script);
   }
 

--- a/packages/core-js-builder/package.json
+++ b/packages/core-js-builder/package.json
@@ -23,10 +23,9 @@
   "dependencies": {
     "core-js": "3.29.1",
     "core-js-compat": "3.29.1",
-    "mkdirp": ">=0.5.5 <1",
-    "webpack": ">=4.46.0 <5"
+    "webpack": ">=4.46.0 || ^5"
   },
   "engines": {
-    "node": ">=8.9.0"
+    "node": ">=12.0.0"
   }
 }


### PR DESCRIPTION
Current node LTS 14.x is already about to be EOL, so it should be safe to update the minimum node version to at least 12.x
This allows to modernize the code and get rid of a dependency (`mkdirp`).

Also allow using webpack 5 to fix issues reported by npm audit when using the `core-js-builder`:

```
6 high severity vulnerabilities

# npm audit report

glob-parent  <5.1.2
Severity: high
glob-parent before 5.1.2 vulnerable to Regular Expression Denial of Service in enclosure regex - https://github.com/advisories/GHSA-ww39-953v-wcq6
fix available via `npm audit fix --force`
Will install core-js-builder@3.6.5, which is a breaking change
node_modules/watchpack-chokidar2/node_modules/glob-parent
  chokidar  1.0.0-rc1 - 2.1.8
  Depends on vulnerable versions of glob-parent
  node_modules/watchpack-chokidar2/node_modules/chokidar
    watchpack-chokidar2  *
    Depends on vulnerable versions of chokidar
    node_modules/watchpack-chokidar2
      watchpack  1.7.2 - 1.7.5
      Depends on vulnerable versions of watchpack-chokidar2
      node_modules/watchpack
        webpack  4.44.0 - 4.46.0
        Depends on vulnerable versions of watchpack
        node_modules/webpack
          core-js-builder  >=3.7.0
          Depends on vulnerable versions of webpack
```

With this PR: `found 0 vulnerabilities`