### PR TITLE
Add guard for ActiveXObject

### DIFF
--- a/packages/core-js/internals/object-create.js
+++ b/packages/core-js/internals/object-create.js
@@ -53,7 +53,9 @@ var NullProtoObjectViaIFrame = function () {
 var activeXDocument;
 var NullProtoObject = function () {
   try {
-    activeXDocument = new ActiveXObject('htmlfile');
+    if (ActiveXObject) {
+      activeXDocument = new ActiveXObject('htmlfile');
+    }
   } catch (error) { /* ignore */ }
   NullProtoObject = typeof document != 'undefined'
     ? document.domain && activeXDocument


### PR DESCRIPTION
My org has a build artifact linting system which gets tripped up by the try/catch block around Object.create. This would be solved for us with an `if` statement as proposed in this PR. Is it possible to get this change added?