### PR TITLE
Update Decorator Metadata proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 ##### Unreleased
+- [Decorator Metadata proposal](https://github.com/tc39/proposal-decorator-metadata):
+  - Moved to Stage 3, [May 2023 TC39 meeting](https://github.com/babel/proposals/issues/88#issuecomment-1553366034)
+  - Added `Function.prototype[Symbol.metadata]` (`=== null`), [May 2023 TC39 meeting](https://github.com/babel/proposals/issues/88#issuecomment-1550313363)
+  - Added `/actual/` entries
 - [Iterator Helpers Stage 3 proposal](https://github.com/tc39/proposal-iterator-helpers):
   - Changed `Symbol.iterator` fallback from callable check to `undefined` / `null` check, May 2023 TC39 meeting, [proposal-iterator-helpers/272](https://github.com/tc39/proposal-iterator-helpers/pull/272)
   - Removed `IsCallable` check on `NextMethod`, deferring errors to `Call` site, May 2023 TC39 meeting, [proposal-iterator-helpers/274](https://github.com/tc39/proposal-iterator-helpers/pull/274)

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ structuredClone(new Set([1, 2, 3])); // => new Set([1, 2, 3])
       - [`ArrayBuffer.prototype.transfer` and friends](#arraybufferprototypetransfer-and-friends)
       - [Explicit resource management](#explicit-resource-management)
       - [Well-formed unicode strings](#well-formed-unicode-strings)
+      - [`Symbol.metadata` for decorators metadata proposal](#symbolmetadata-for-decorators-metadata-proposal)
     - [Stage 2 proposals](#stage-2-proposals)
       - [`AsyncIterator` helpers](#asynciterator-helpers)
       - [`Iterator.range`](#iteratorrange)
@@ -167,7 +168,6 @@ structuredClone(new Set([1, 2, 3])); // => new Set([1, 2, 3])
       - [`String.dedent`](#stringdedent)
       - [Async explicit resource management](#async-explicit-resource-management)
       - [`Symbol` predicates](#symbol-predicates)
-      - [`Symbol.metadata` for decorators metadata proposal](#symbolmetadata-for-decorators-metadata-proposal)
     - [Stage 1 proposals](#stage-1-proposals)
       - [`Observable`](#observable)
       - [New collections methods](#new-collections-methods)
@@ -2402,6 +2402,23 @@ core-js(-pure)/actual|full/string(/virtual)/to-well-formed
 'a💩b'.toWellFormed();      // => 'a💩b'
 'a\uD83Db'.toWellFormed();  // => 'a�b'
 ```
+##### [`Symbol.metadata` for decorators metadata proposal](https://github.com/tc39/proposal-decorator-metadata)[⬆](#index)
+Modules [`esnext.symbol.metadata`](https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/esnext.symbol.metadata.js) and [`esnext.function.metadata`](https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/esnext.function.metadata.js).
+```js
+class Symbol {
+  static metadata: @@metadata;
+}
+
+class Function {
+  @@metadata: null;
+}
+```
+[*CommonJS entry points:*](#commonjs-api)
+```
+core-js/proposals/decorator-metadata-v2
+core-js(-pure)/actual|full/symbol/metadata
+core-js(-pure)/actual|full/function/metadata
+```
 
 #### Stage 2 proposals[⬆](#index)
 [*CommonJS entry points:*](#commonjs-api)
@@ -2615,18 +2632,6 @@ Symbol.isRegistered(Symbol('key')); // => false
 
 Symbol.isWellKnown(Symbol.iterator); // => true
 Symbol.isWellKnown(Symbol('key')); // => false
-```
-##### [`Symbol.metadata` for decorators metadata proposal](https://github.com/tc39/proposal-decorator-metadata)[⬆](#index)
-Module [`esnext.symbol.metadata`](https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/esnext.symbol.metadata.js).
-```js
-class Symbol {
-  static metadata: @@metadata;
-}
-```
-[*CommonJS entry points:*](#commonjs-api)
-```js
-core-js/proposals/decorator-metadata-v2
-core-js(-pure)/full/symbol/metadata
 ```
 
 #### Stage 1 proposals[⬆](#index)

--- a/packages/core-js-compat/src/data.mjs
+++ b/packages/core-js-compat/src/data.mjs
@@ -1958,6 +1958,8 @@ export const data = {
   },
   'esnext.function.is-constructor': {
   },
+  'esnext.function.metadata': {
+  },
   // TODO: Remove from `core-js@4`
   'esnext.function.un-this': {
   },

--- a/packages/core-js-compat/src/modules-by-versions.mjs
+++ b/packages/core-js-compat/src/modules-by-versions.mjs
@@ -202,4 +202,7 @@ export default {
   '3.30': [
     'web.url.can-parse',
   ],
+  3.31: [
+    'esnext.function.metadata',
+  ],
 };

--- a/packages/core-js/actual/function/index.js
+++ b/packages/core-js/actual/function/index.js
@@ -1,3 +1,4 @@
 var parent = require('../../stable/function');
+require('../../modules/esnext.function.metadata');
 
 module.exports = parent;

--- a/packages/core-js/actual/function/metadata.js
+++ b/packages/core-js/actual/function/metadata.js
@@ -1,0 +1,3 @@
+require('../../modules/esnext.function.metadata');
+
+module.exports = null;

--- a/packages/core-js/actual/symbol/index.js
+++ b/packages/core-js/actual/symbol/index.js
@@ -1,5 +1,7 @@
 var parent = require('../../stable/symbol');
 
+require('../../modules/esnext.function.metadata');
 require('../../modules/esnext.symbol.dispose');
+require('../../modules/esnext.symbol.metadata');
 
 module.exports = parent;

--- a/packages/core-js/actual/symbol/metadata.js
+++ b/packages/core-js/actual/symbol/metadata.js
@@ -1,0 +1,5 @@
+require('../../modules/esnext.function.metadata');
+require('../../modules/esnext.symbol.metadata');
+var WrappedWellKnownSymbolModule = require('../../internals/well-known-symbol-wrapped');
+
+module.exports = WrappedWellKnownSymbolModule.f('metadata');

--- a/packages/core-js/full/function/metadata.js
+++ b/packages/core-js/full/function/metadata.js
@@ -1,0 +1,3 @@
+var parent = require('../../actual/function/metadata');
+
+module.exports = parent;

--- a/packages/core-js/full/symbol/index.js
+++ b/packages/core-js/full/symbol/index.js
@@ -3,10 +3,9 @@ require('../../modules/esnext.symbol.async-dispose');
 require('../../modules/esnext.symbol.is-registered');
 require('../../modules/esnext.symbol.is-well-known');
 require('../../modules/esnext.symbol.matcher');
-require('../../modules/esnext.symbol.metadata-key');
 require('../../modules/esnext.symbol.observable');
 // TODO: Remove from `core-js@4`
-require('../../modules/esnext.symbol.metadata');
+require('../../modules/esnext.symbol.metadata-key');
 require('../../modules/esnext.symbol.pattern-match');
 require('../../modules/esnext.symbol.replace-all');
 

--- a/packages/core-js/full/symbol/metadata.js
+++ b/packages/core-js/full/symbol/metadata.js
@@ -1,4 +1,3 @@
-require('../../modules/esnext.symbol.metadata');
-var WrappedWellKnownSymbolModule = require('../../internals/well-known-symbol-wrapped');
+var parent = require('../../actual/symbol/metadata');
 
-module.exports = WrappedWellKnownSymbolModule.f('metadata');
+module.exports = parent;

--- a/packages/core-js/modules/esnext.function.metadata.js
+++ b/packages/core-js/modules/esnext.function.metadata.js
@@ -1,0 +1,13 @@
+var wellKnownSymbol = require('../internals/well-known-symbol');
+var defineProperty = require('../internals/object-define-property').f;
+
+var METADATA = wellKnownSymbol('metadata');
+var FunctionPrototype = Function.prototype;
+
+// Function.prototype[@@metadata]
+// https://github.com/tc39/proposal-decorator-metadata
+if (FunctionPrototype[METADATA] === undefined) {
+  defineProperty(FunctionPrototype, METADATA, {
+    value: null
+  });
+}

--- a/packages/core-js/proposals/decorator-metadata-v2.js
+++ b/packages/core-js/proposals/decorator-metadata-v2.js
@@ -1,2 +1,3 @@
 // https://github.com/tc39/proposal-decorator-metadata
+require('../modules/esnext.function.metadata');
 require('../modules/esnext.symbol.metadata');

--- a/packages/core-js/stage/2.js
+++ b/packages/core-js/stage/2.js
@@ -3,7 +3,6 @@ var parent = require('./3');
 require('../proposals/array-is-template-object');
 require('../proposals/async-explicit-resource-management');
 require('../proposals/async-iterator-helpers');
-require('../proposals/decorator-metadata-v2');
 require('../proposals/iterator-range');
 require('../proposals/map-upsert-stage-2');
 require('../proposals/string-dedent');

--- a/packages/core-js/stage/3.js
+++ b/packages/core-js/stage/3.js
@@ -3,6 +3,7 @@ var parent = require('./4');
 require('../proposals/array-from-async-stage-2');
 require('../proposals/array-grouping-stage-3-2');
 require('../proposals/array-buffer-transfer');
+require('../proposals/decorator-metadata-v2');
 require('../proposals/explicit-resource-management');
 require('../proposals/iterator-helpers-stage-3-2');
 require('../proposals/json-parse-with-source');

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -1535,6 +1535,9 @@ GLOBAL.tests = {
   'esnext.function.is-constructor': function () {
     return Function.isConstructor;
   },
+  'esnext.function.metadata': function () {
+    return Function.prototype[Symbol.metadata] === null;
+  },
   'esnext.iterator.constructor': function () {
     try {
       Iterator({});

--- a/tests/entries/unit.mjs
+++ b/tests/entries/unit.mjs
@@ -657,6 +657,7 @@ for (PATH of ['core-js-pure', 'core-js']) {
     ok(typeof load(NS, 'async-iterator/some') == 'function');
     ok(typeof load(NS, 'async-iterator/take') == 'function');
     ok(typeof load(NS, 'async-iterator/to-array') == 'function');
+    ok(load(NS, 'function/metadata') === null);
     ok(typeof load(NS, 'iterator') == 'function');
     ok(typeof load(NS, 'iterator/drop') == 'function');
     ok(typeof load(NS, 'iterator/every') == 'function');
@@ -686,6 +687,7 @@ for (PATH of ['core-js-pure', 'core-js']) {
     ok(load(NS, 'string/to-well-formed')('a') === 'a');
     ok(load(NS, 'string/virtual/to-well-formed').call('a') === 'a');
     ok(load(NS, 'symbol/dispose'));
+    ok(load(NS, 'symbol/metadata'));
     ok(new (load(NS, 'suppressed-error'))(1, 2).suppressed === 2);
     ok(typeof load(NS, 'disposable-stack') == 'function');
     ok(typeof load(NS, 'disposable-stack/constructor') == 'function');
@@ -826,7 +828,6 @@ for (PATH of ['core-js-pure', 'core-js']) {
     ok(load(NS, 'symbol/is-registered')(1) === false);
     ok(load(NS, 'symbol/is-well-known')(1) === false);
     ok(load(NS, 'symbol/matcher'));
-    ok(load(NS, 'symbol/metadata'));
     ok(load(NS, 'symbol/metadata-key'));
     ok(load(NS, 'symbol/observable'));
     ok(load(NS, 'symbol/pattern-match'));

--- a/tests/unit-global/esnext.function.metadata.js
+++ b/tests/unit-global/esnext.function.metadata.js
@@ -1,0 +1,4 @@
+QUnit.test('Function#@@metadata', assert => {
+  assert.true(Symbol.metadata in Function.prototype);
+  assert.same(Function.prototype[Symbol.metadata], null, 'is null');
+});

--- a/tests/unit-pure/esnext.function.metadata.js
+++ b/tests/unit-pure/esnext.function.metadata.js
@@ -1,0 +1,6 @@
+import Symbol from 'core-js-pure/actual/symbol';
+
+QUnit.test('Function#@@metadata', assert => {
+  assert.true(Symbol.metadata in Function.prototype);
+  assert.same(Function.prototype[Symbol.metadata], null, 'is null');
+});

--- a/tests/unit-pure/esnext.symbol.metadata.js
+++ b/tests/unit-pure/esnext.symbol.metadata.js
@@ -1,4 +1,4 @@
-import Symbol from 'core-js-pure/full/symbol';
+import Symbol from 'core-js-pure/actual/symbol';
 
 QUnit.test('Symbol.metadata', assert => {
   assert.true('metadata' in Symbol, 'Symbol.metadata available');


### PR DESCRIPTION
- [Decorator Metadata proposal](https://github.com/tc39/proposal-decorator-metadata):
  - Moved to Stage 3, [May 2023 TC39 meeting](https://github.com/babel/proposals/issues/88#issuecomment-1553366034)
  - Added `Function.prototype[Symbol.metadata]` (`=== null`), [May 2023 TC39 meeting](https://github.com/babel/proposals/issues/88#issuecomment-1550313363)
  - Added `/actual/` entries