### PR TITLE
Fix IEEE754 rounding rule from truncation to roundTiesToEven

### DIFF
--- a/packages/core-js/internals/ieee754.js
+++ b/packages/core-js/internals/ieee754.js
@@ -1,11 +1,11 @@
 'use strict';
 // IEEE754 conversions based on https://github.com/feross/ieee754
-var trunc = require("../internals/math-trunc");
+var sign = require('../internals/math-sign');
+var trunc = require('../internals/math-trunc');
 
 var $Array = Array;
 var abs = Math.abs;
 var pow = Math.pow;
-var sign = Math.sign;
 var floor = Math.floor;
 var log = Math.log;
 var LN2 = Math.LN2;
@@ -16,7 +16,7 @@ var roundToEven = function (number) {
   if (delta > 0.5 || delta === 0.5 && truncated % 2 !== 0) {
     return truncated + sign(number);
   } return truncated;
-}
+};
 
 var pack = function (number, mantissaLength, bytes) {
   var buffer = $Array(bytes);
@@ -24,7 +24,7 @@ var pack = function (number, mantissaLength, bytes) {
   var eMax = (1 << exponentLength) - 1;
   var eBias = eMax >> 1;
   var rt = mantissaLength === 23 ? pow(2, -24) - pow(2, -77) : 0;
-  var sign = number < 0 || number === 0 && 1 / number < 0 ? 1 : 0;
+  var s = number < 0 || number === 0 && 1 / number < 0 ? 1 : 0;
   var index = 0;
   var exponent, mantissa, c;
   number = abs(number);
@@ -72,7 +72,7 @@ var pack = function (number, mantissaLength, bytes) {
     exponent /= 256;
     exponentLength -= 8;
   }
-  buffer[--index] |= sign * 128;
+  buffer[--index] |= s * 128;
   return buffer;
 };
 
@@ -83,10 +83,10 @@ var unpack = function (buffer, mantissaLength) {
   var eBias = eMax >> 1;
   var nBits = exponentLength - 7;
   var index = bytes - 1;
-  var sign = buffer[index--];
-  var exponent = sign & 127;
+  var s = buffer[index--];
+  var exponent = s & 127;
   var mantissa;
-  sign >>= 7;
+  s >>= 7;
   while (nBits > 0) {
     exponent = exponent * 256 + buffer[index--];
     nBits -= 8;
@@ -101,11 +101,11 @@ var unpack = function (buffer, mantissaLength) {
   if (exponent === 0) {
     exponent = 1 - eBias;
   } else if (exponent === eMax) {
-    return mantissa ? NaN : sign ? -Infinity : Infinity;
+    return mantissa ? NaN : s ? -Infinity : Infinity;
   } else {
     mantissa = mantissa + pow(2, mantissaLength);
     exponent = exponent - eBias;
-  } return (sign ? -1 : 1) * mantissa * pow(2, exponent - mantissaLength);
+  } return (s ? -1 : 1) * mantissa * pow(2, exponent - mantissaLength);
 };
 
 module.exports = {

--- a/packages/core-js/internals/ieee754.js
+++ b/packages/core-js/internals/ieee754.js
@@ -1,11 +1,22 @@
 'use strict';
 // IEEE754 conversions based on https://github.com/feross/ieee754
+var trunc = require("../internals/math-trunc");
+
 var $Array = Array;
 var abs = Math.abs;
 var pow = Math.pow;
+var sign = Math.sign;
 var floor = Math.floor;
 var log = Math.log;
 var LN2 = Math.LN2;
+
+var roundToEven = function (number) {
+  var truncated = trunc(number);
+  var delta = abs(number - truncated);
+  if (delta > 0.5 || delta === 0.5 && truncated % 2 !== 0) {
+    return truncated + sign(number);
+  } return truncated;
+}
 
 var pack = function (number, mantissaLength, bytes) {
   var buffer = $Array(bytes);
@@ -42,10 +53,10 @@ var pack = function (number, mantissaLength, bytes) {
       mantissa = 0;
       exponent = eMax;
     } else if (exponent + eBias >= 1) {
-      mantissa = (number * c - 1) * pow(2, mantissaLength);
+      mantissa = roundToEven((number * c - 1) * pow(2, mantissaLength));
       exponent = exponent + eBias;
     } else {
-      mantissa = number * pow(2, eBias - 1) * pow(2, mantissaLength);
+      mantissa = roundToEven(number * pow(2, eBias - 1) * pow(2, mantissaLength));
       exponent = 0;
     }
   }

--- a/tests/unit-global/esnext.math.f16round.js
+++ b/tests/unit-global/esnext.math.f16round.js
@@ -32,8 +32,8 @@ QUnit.test('Math.f16round', assert => {
   assert.same(f16round(-minFloat16), -minFloat16);
   assert.same(f16round(minFloat16 / 2), 0);
   assert.same(f16round(-minFloat16 / 2), -0);
-  assert.same(f16round(minFloat16 / 2 + 2 ** -25), minFloat16);
-  assert.same(f16round(-minFloat16 / 2 - 2 ** -25), -minFloat16);
+  assert.same(f16round(2.980232238769531911744490042422139897126953655970282852649688720703125e-8), minFloat16);
+  assert.same(f16round(-2.980232238769531911744490042422139897126953655970282852649688720703125e-8), -minFloat16);
 
   assert.same(f16round(1.337), 1.3369140625);
 

--- a/tests/unit-pure/esnext.math.f16round.js
+++ b/tests/unit-pure/esnext.math.f16round.js
@@ -31,8 +31,8 @@ QUnit.test('Math.f16round', assert => {
   assert.same(f16round(-minFloat16), -minFloat16);
   assert.same(f16round(minFloat16 / 2), 0);
   assert.same(f16round(-minFloat16 / 2), -0);
-  assert.same(f16round(minFloat16 / 2 + 2 ** -25), minFloat16);
-  assert.same(f16round(-minFloat16 / 2 - 2 ** -25), -minFloat16);
+  assert.same(f16round(2.980232238769531911744490042422139897126953655970282852649688720703125e-8), minFloat16);
+  assert.same(f16round(-2.980232238769531911744490042422139897126953655970282852649688720703125e-8), -minFloat16);
 
   assert.same(f16round(1.337), 1.3369140625);
 


### PR DESCRIPTION
The decimal part of mantissa variable is truncated by bitwise operations, but it should be rounded (to even).

related https://github.com/petamoriken/float16/issues/952