### PR TITLE
Add `clearTimeout`

### DIFF
--- a/packages/core-js/modules/web.set-timeout.js
+++ b/packages/core-js/modules/web.set-timeout.js
@@ -4,9 +4,14 @@ var global = require('../internals/global');
 var schedulersFix = require('../internals/schedulers-fix');
 
 var setTimeout = schedulersFix(global.setTimeout, true);
+var clearTimeout = schedulersFix(global.clearTimeout, true);
 
 // Bun / IE9- setTimeout additional parameters fix
 // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout
 $({ global: true, bind: true, forced: global.setTimeout !== setTimeout }, {
   setTimeout: setTimeout
+});
+
+$({ global: true, bind: true, forced: global.clearTimeout !== clearTimeout }, {
+  clearTimeout: clearTimeout
 });

--- a/tests/unit-global/web.set-timeout.js
+++ b/tests/unit-global/web.set-timeout.js
@@ -17,8 +17,8 @@ QUnit.test('setTimeout / clearTimeout', assert => {
       clearTimeout(setTimeout(resolve, 10));
     });
   }).then(() => {
-    assert.avoid('clearImmediate works with wrapped setTimeout');
+    assert.avoid('clearTimeout works with wrapped setTimeout');
   }, () => {
-    assert.required('clearImmediate works with wrapped setTimeout');
+    assert.required('clearTimeout works with wrapped setTimeout');
   });
 });


### PR DESCRIPTION
The functionality already existed and was tested by unit tests. This change exports it and clarifies misleading descriptions of its unit tests.