### PR TITLE
Fix esnext.map.delete-all.js

### DIFF
--- a/packages/core-js/modules/esnext.map.delete-all.js
+++ b/packages/core-js/modules/esnext.map.delete-all.js
@@ -8,11 +8,9 @@ var remove = require('../internals/map-helpers').remove;
 $({ target: 'Map', proto: true, real: true, forced: true }, {
   deleteAll: function deleteAll(/* ...elements */) {
     var collection = aMap(this);
-    var allDeleted = true;
-    var wasDeleted;
     for (var k = 0, len = arguments.length; k < len; k++) {
-      wasDeleted = remove(collection, arguments[k]);
-      allDeleted = allDeleted && wasDeleted;
-    } return !!allDeleted;
+      remove(collection, arguments[k]);
+    }
+    return collection;
   }
 });


### PR DESCRIPTION
Currently the `Map#deleteAll` polyfill is returning a boolean whether it deleted everything successfully or not, this is not the correct behavior of the current ES proposal: https://tc39.es/proposal-collection-methods/#Map.prototype.deleteAll

The expected behavior is to return the map itself (`this`), so I've also removed all the successful deletion tracking code as it was no longer needed.