### PR TITLE
Fix global object retrieval on Duktape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
 ##### Unreleased
+- Fixed an issue getting the global object on Duktape, [#1303](https://github.com/zloirock/core-js/issues/1303)
 - Compat data improvements:
   - Added [Deno 1.38](https://deno.com/blog/v1.38) compat data mapping
   - [`Array.fromAsync`](https://github.com/tc39/proposal-array-from-async) marked as [supported from Deno 1.38](https://github.com/denoland/deno/pull/21048)

--- a/packages/core-js/internals/global.js
+++ b/packages/core-js/internals/global.js
@@ -11,5 +11,6 @@ module.exports =
   // eslint-disable-next-line no-restricted-globals -- safe
   check(typeof self == 'object' && self) ||
   check(typeof global == 'object' && global) ||
+  check(typeof this == 'object' && this) ||
   // eslint-disable-next-line no-new-func -- fallback
-  (function () { return this; })() || this || Function('return this')();
+  (function () { return this; })() || Function('return this')();


### PR DESCRIPTION
Fixes #1303 by adding a check on `this` as proposed in #1303.