### PR TITLE
Push an empty string when testing whether [].length is writable

### DIFF
--- a/packages/core-js/modules/es.array.push.js
+++ b/packages/core-js/modules/es.array.push.js
@@ -15,7 +15,7 @@ var INCORRECT_TO_LENGTH = fails(function () {
 var properErrorOnNonWritableLength = function () {
   try {
     // eslint-disable-next-line es/no-object-defineproperty -- safe
-    Object.defineProperty([], 'length', { writable: false }).push();
+    Object.defineProperty([], 'length', { writable: false }).push('');
   } catch (error) {
     return error instanceof TypeError;
   }


### PR DESCRIPTION
It seems that the current version of Chrome (v119.0.6045.199, on macOS 14.1.1) is not throwing the expected error when calling `push` with no arguments. 

This leads to `Array.prototype.push` being polyfilled more than expected, affecting performance. 

<img width="650" alt="image" src="https://github.com/zloirock/core-js/assets/14294/fef92f53-cf59-4764-b56b-bd07faf584f0">

Firefox and Safari throw the expected error both with and without this change, although the message is slightly different in Firefox when pushing an empty string.

Firefox 120.0.1:

<img width="740" alt="image" src="https://github.com/zloirock/core-js/assets/14294/91885104-2c2a-4d67-aac5-8c4bd4bb813b">

Safari 17.1:

<img width="460" alt="image" src="https://github.com/zloirock/core-js/assets/14294/ba64a4f2-016a-4020-86f8-f3a01a618e7c">

I haven't tested with any other browsers or versions.

It's possible that this does actually indicate a case where `Array.prototype.push` needs to be polyfilled, of course, in which case feel free to close this PR.
