### PR TITLE
Fix create-property.js

### DIFF
--- a/packages/core-js/internals/create-property.js
+++ b/packages/core-js/internals/create-property.js
@@ -5,6 +5,5 @@ var createPropertyDescriptor = require('../internals/create-property-descriptor'
 
 module.exports = function (object, key, value) {
   var propertyKey = toPropertyKey(key);
-  if (propertyKey in object) definePropertyModule.f(object, propertyKey, createPropertyDescriptor(0, value));
-  else object[propertyKey] = value;
+  definePropertyModule.f(object, propertyKey, createPropertyDescriptor(0, value));
 };


### PR DESCRIPTION
This PR is for https://github.com/zloirock/core-js/issues/1322

The changes are as follows

```js
module.exports = function (object, key, value) {
  var propertyKey = toPropertyKey(key);
  if (propertyKey in object) definePropertyModule.f(object, propertyKey, createPropertyDescriptor(0, value));
  else object[propertyKey] = value;
};
```

```js
module.exports = function (object, key, value) {
  var propertyKey = toPropertyKey(key);
  definePropertyModule.f(object, propertyKey, createPropertyDescriptor(0, value));
};
```

I am not certain about the impact of this patch on performance - in case the existing code was intentionally written for performance benefits like JIT optimization, please handle it appropriately at your discretion.