### PR TITLE
Add missed check in `array-reduce.js`

### DIFF
--- a/packages/core-js/internals/array-reduce.js
+++ b/packages/core-js/internals/array-reduce.js
@@ -13,6 +13,7 @@ var createMethod = function (IS_RIGHT) {
     var self = IndexedObject(O);
     var length = lengthOfArrayLike(O);
     aCallable(callbackfn);
+    if (length === 0 && argumentsLength < 2) throw new $TypeError('Reduce of empty array with no initial value');
     var index = IS_RIGHT ? length - 1 : 0;
     var i = IS_RIGHT ? -1 : 1;
     if (argumentsLength < 2) while (true) {


### PR DESCRIPTION
This PR is about fixing [issue/1327](https://github.com/zloirock/core-js/issues/1327)

Missed check for [line 4 of spec.](https://262.ecma-international.org/14.0/#sec-array.prototype.reduce) is added