### PR TITLE
Fix Object.setPrototypeOf

### DIFF
--- a/packages/core-js/internals/object-set-prototype-of.js
+++ b/packages/core-js/internals/object-set-prototype-of.js
@@ -1,7 +1,8 @@
 'use strict';
 /* eslint-disable no-proto -- safe */
 var uncurryThisAccessor = require('../internals/function-uncurry-this-accessor');
-var anObject = require('../internals/an-object');
+var isObject = require('../internals/is-object');
+var requireObjectCoercible = require('../internals/require-object-coercible');
 var aPossiblePrototype = require('../internals/a-possible-prototype');
 
 // `Object.setPrototypeOf` method
@@ -18,8 +19,9 @@ module.exports = Object.setPrototypeOf || ('__proto__' in {} ? function () {
     CORRECT_SETTER = test instanceof Array;
   } catch (error) { /* empty */ }
   return function setPrototypeOf(O, proto) {
-    anObject(O);
+    requireObjectCoercible(O);
     aPossiblePrototype(proto);
+    if (!isObject(O)) return O;
     if (CORRECT_SETTER) setter(O, proto);
     else O.__proto__ = proto;
     return O;


### PR DESCRIPTION
This PR is about fixing [issue/1329](https://github.com/zloirock/core-js/issues/1329)

```js
const f = require('core-js-pure/actual/object/set-prototype-of');
f(1, {}) === 1; // This should be true, without throwing
```

`Object.setPrototypeOf` should not throw when `O` is coercible - This is the related [spec](https://tc39.es/ecma262/#sec-object.setprototypeof)