### PR TITLE
Fix `Array.from`

### DIFF
--- a/packages/core-js/internals/array-from.js
+++ b/packages/core-js/internals/array-from.js
@@ -26,9 +26,9 @@ module.exports = function from(arrayLike /* , mapfn = undefined, thisArg = undef
   var length, result, step, iterator, next, value;
   // if the target is not iterable or it's an array with the default iterator - use a simple case
   if (iteratorMethod && !(this === $Array && isArrayIteratorMethod(iteratorMethod))) {
+    result = IS_CONSTRUCTOR ? new this() : [];
     iterator = getIterator(O, iteratorMethod);
     next = iterator.next;
-    result = IS_CONSTRUCTOR ? new this() : [];
     for (;!(step = call(next, iterator)).done; index++) {
       value = mapping ? callWithSafeIterationClosing(iterator, mapfn, [step.value, index], true) : step.value;
       createProperty(result, index, value);


### PR DESCRIPTION
Following code behaves differently depending on whether the native version is loaded, or if the polyfill is required and loaded:

```javascript
const f = require("core-js-pure/es/array/from");

const a = function () {
    throw 42;
};

const b = {};
b[Symbol.iterator] = () => undefined

f.call(a, b) // throw '42' in native, throw 'TypeError' in polyfill
```

The difference comes from the order of construction and type checking - `construct` should be done first. [spec](https://tc39.es/ecma262/#sec-array.from)

```javascript
try {
    f.call(a, b)
} catch (e) {
    e === 42 // This should be true
}
```