### PR TITLE
es.promise.with-resolvers Android Chrome compability

### DIFF
--- a/packages/core-js-compat/src/data.mjs
+++ b/packages/core-js-compat/src/data.mjs
@@ -1206,6 +1206,7 @@ export const data = {
     safari: '11.0',
   },
   'es.promise.with-resolvers': {
+    android: '126',
     bun: '0.7.1',
     chrome: '119',
     firefox: '121',


### PR DESCRIPTION
Just had core-js miss this on Chrome 120 and 125

https://caniuse.com/?search=Promise.withResolvers