### PR TITLE
Fix `es.regexp.constructor - handleNCG`  - consider captured groups inside non-capturing groups

### DIFF
--- a/packages/core-js/modules/es.regexp.constructor.js
+++ b/packages/core-js/modules/es.regexp.constructor.js
@@ -96,9 +96,9 @@ var handleNCG = function (string) {
         break;
       case chr === '(':
         result += chr;
-        if (stringSlice(string, index + 1, index + 3) == "?:") { // avoid groupid increment in non-capturing group
+        if (stringSlice(string, index + 1, index + 3) === '?:') { // avoid groupid increment in non-capturing group
           continue;
-        } if (exec(IS_NCG, stringSlice(string, index + 1))) {
+        } else if (exec(IS_NCG, stringSlice(string, index + 1))) {
           index += 2;
           ncg = true;
         }

--- a/packages/core-js/modules/es.regexp.constructor.js
+++ b/packages/core-js/modules/es.regexp.constructor.js
@@ -95,11 +95,13 @@ var handleNCG = function (string) {
         brackets = true;
         break;
       case chr === '(':
-        if (exec(IS_NCG, stringSlice(string, index + 1))) {
+        result += chr;
+        if (stringSlice(string, index + 1, index + 3) == "?:") { // avoid groupid increment in non-capturing group
+          continue;
+        } if (exec(IS_NCG, stringSlice(string, index + 1))) {
           index += 2;
           ncg = true;
         }
-        result += chr;
         groupid++;
         continue;
       case chr === '>' && ncg:

--- a/tests/unit-global/es.regexp.constructor.js
+++ b/tests/unit-global/es.regexp.constructor.js
@@ -84,6 +84,13 @@ if (DESCRIPTORS) {
     const { groups } = RegExp('foo:(?<foo>\\w+),bar:(?<bar>\\w+)').exec('foo:abc,bar:def');
     assert.same(getPrototypeOf(groups), null, 'null prototype');
     assert.deepEqual(groups, { foo: 'abc', bar: 'def' }, 'NCG #3');
+    const { groups: nonCaptured, length } = RegExp('foo:(?:value=(?<foo>\\w+)),bar:(?:value=(?<bar>\\w+))').exec('foo:value=abc,bar:value=def');
+    assert.deepEqual(nonCaptured, { foo: 'abc', bar: 'def' }, 'NCG #4');
+    assert.same(length, 3, 'incorrect number of matched entries #1')
+
+    const { groups: skipBar } = RegExp('foo:(?<foo>\\w+),bar:(\\w+),buz:(?<buz>\\w+)').exec('foo:abc,bar:def,buz:ghi');
+    assert.deepEqual(skipBar, { foo: 'abc', buz: 'ghi' }, 'NCG #5');
+
     // fails in Safari
     // assert.same(Object.getPrototypeOf(groups), null, 'NCG #4');
     assert.same('foo:abc,bar:def'.replace(RegExp('foo:(?<foo>\\w+),bar:(?<bar>\\w+)'), '$<bar>,$<foo>'), 'def,abc', 'replace #1');

--- a/tests/unit-global/es.regexp.constructor.js
+++ b/tests/unit-global/es.regexp.constructor.js
@@ -84,10 +84,12 @@ if (DESCRIPTORS) {
     const { groups } = RegExp('foo:(?<foo>\\w+),bar:(?<bar>\\w+)').exec('foo:abc,bar:def');
     assert.same(getPrototypeOf(groups), null, 'null prototype');
     assert.deepEqual(groups, { foo: 'abc', bar: 'def' }, 'NCG #3');
+    // eslint-disable-next-line regexp/no-useless-non-capturing-group -- required for testing
     const { groups: nonCaptured, length } = RegExp('foo:(?:value=(?<foo>\\w+)),bar:(?:value=(?<bar>\\w+))').exec('foo:value=abc,bar:value=def');
     assert.deepEqual(nonCaptured, { foo: 'abc', bar: 'def' }, 'NCG #4');
-    assert.same(length, 3, 'incorrect number of matched entries #1')
+    assert.same(length, 3, 'incorrect number of matched entries #1');
 
+    // eslint-disable-next-line regexp/no-unused-capturing-group -- required for testing
     const { groups: skipBar } = RegExp('foo:(?<foo>\\w+),bar:(\\w+),buz:(?<buz>\\w+)').exec('foo:abc,bar:def,buz:ghi');
     assert.deepEqual(skipBar, { foo: 'abc', buz: 'ghi' }, 'NCG #5');
 


### PR DESCRIPTION
`handleNCG` method from [es.regexp.constructor](https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/es.regexp.constructor.js) does not work correctly in some cases.

If named captured group placed inside non-capturing group(or other group, that doesn't follow `(?<group_name>...)` pattern) then group id counter extra incremented.
```js
 case chr === '(':
        if (exec(IS_NCG, stringSlice(string, index + 1))) {
          index += 2;
          ncg = true;
          // where increment is needed
        }
        result += chr;
        groupid++;  // where actually incremented
        continue;
```

Real example: [H_REGEX](https://github.com/microsoft/vscode/blob/main/src/vs/base/browser/dom.ts#L2258C1-L2258C110) from vscode repository.
`const H_REGEX = /(?<tag>[\w\-]+)?(?:#(?<id>[\w\-]+))?(?<class>(?:\.(?:[\w\-]+))*)(?:@(?<name>(?:[\w\_])+))?/;`

When it used through RegExp constructor `new RegExp('(?<tag>[\\w\\-]+)?(?:#(?<id>[\\w\\-]+))?(?<class>(?:\\.(?:[\\w\\-]+))*)(?:@(?<name>(?:[\\w\\_])+))?')`, exec method return wrong groups values. Tested on ` 'div.editor.original@original'` input value.
With polyfill:
```json
{
    "tag": "div",
    "id": ".editor.original",
    "name": undefined,
    "class": "original"
}
```
Native:
```json
{
    "tag": "div",
    "id": undefined,
    "class": ".editor.original",
    "name": "original"
}
```

[Link](http://es6.zloirock.ru/#let%20reg%20%3D%20new%20RegExp('(%3F%3Ctag%3E%5B%5C%5Cw%5C%5C-%5D%2B)%3F(%3F%3A%23(%3F%3Cid%3E%5B%5C%5Cw%5C%5C-%5D%2B))%3F(%3F%3Cclass%3E(%3F%3A%5C%5C.(%3F%3A%5B%5C%5Cw%5C%5C-%5D%2B))*)(%3F%3A%40(%3F%3Cname%3E(%3F%3A%5B%5C%5Cw%5C%5C_%5D)%2B))%3F')%3B%0Alet%20input%20%3D%20'div.editor.original%40original'%3B%0Aconsole.log(reg.exec(input))) to test