### PR TITLE
Fix to avoid minification problem with esbuild

### DIFF
--- a/packages/core-js/internals/uid.js
+++ b/packages/core-js/internals/uid.js
@@ -3,7 +3,7 @@ var uncurryThis = require('../internals/function-uncurry-this');
 
 var id = 0;
 var postfix = Math.random();
-var toString = uncurryThis(1.0.toString);
+var toString = uncurryThis(1.1.toString);
 
 module.exports = function (key) {
   return 'Symbol(' + (key === undefined ? '' : key) + ')_' + toString(++id + postfix, 36);


### PR DESCRIPTION
esbuild will minify this to 1.toString (removing the zero) which will result in a syntax error in the browser.