### PR TITLE
Make float16 handling more performant

### DIFF
--- a/packages/core-js/modules/esnext.data-view.get-float16.js
+++ b/packages/core-js/modules/esnext.data-view.get-float16.js
@@ -1,7 +1,17 @@
 'use strict';
 var $ = require('../internals/export');
 var uncurryThis = require('../internals/function-uncurry-this');
-var unpackIEEE754 = require('../internals/ieee754').unpack;
+
+const expMask16 = 2 ** 5 - 1, significandMask16 = 2 ** 10 - 1, minSubnormal16 = 2 ** -10 * 2 ** -14, significandDenom16 = 2 ** -10;
+
+function unpackFloat16(bytes) {
+	const sign = bytes >>> 15;
+	const exponent = bytes >>> 10 & expMask16;
+	const significand = bytes & significandMask16;
+	if (exponent === expMask16) return significand === 0 ? (sign === 0 ? Infinity : -Infinity) : NaN;
+	if (exponent === 0) return significand * (sign === 0 ? minSubnormal16 : -minSubnormal16);
+	return 2 ** (exponent - 15) * (sign === 0 ? 1 + significand * significandDenom16 : -1 - significand * significandDenom16);
+}
 
 // eslint-disable-next-line es/no-typed-arrays -- safe
 var getUint16 = uncurryThis(DataView.prototype.getUint16);
@@ -11,6 +21,6 @@ var getUint16 = uncurryThis(DataView.prototype.getUint16);
 $({ target: 'DataView', proto: true }, {
   getFloat16: function getFloat16(byteOffset /* , littleEndian */) {
     var uint16 = getUint16(this, byteOffset, arguments.length > 1 ? arguments[1] : false);
-    return unpackIEEE754([uint16 & 0xFF, uint16 >> 8 & 0xFF], 10);
+    return unpackFloat16(uint16);
   }
 });

--- a/packages/core-js/modules/esnext.data-view.get-float16.js
+++ b/packages/core-js/modules/esnext.data-view.get-float16.js
@@ -2,18 +2,20 @@
 var $ = require('../internals/export');
 var uncurryThis = require('../internals/function-uncurry-this');
 
-var expMask16 = 31; // 2 ** 5 - 1
-var significandMask16 = 1023; // 2 ** 10 - 1
-var minSubnormal16 = Math.pow(2, -24); // 2 ** -10 * 2 ** -14
-var significandDenom16 = 0.0009765625; // 2 ** -10
+var pow = Math.pow;
+
+var EXP_MASK16 = 31; // 2 ** 5 - 1
+var SIGNIFICAND_MASK16 = 1023; // 2 ** 10 - 1
+var MIN_SUBNORMAL16 = pow(2, -24); // 2 ** -10 * 2 ** -14
+var SIGNIFICAND_DENOM16 = 0.0009765625; // 2 ** -10
 
 function unpackFloat16(bytes) {
   var sign = bytes >>> 15;
-  var exponent = bytes >>> 10 & expMask16;
-  var significand = bytes & significandMask16;
-  if (exponent === expMask16) return significand === 0 ? (sign === 0 ? Infinity : -Infinity) : NaN;
-  if (exponent === 0) return significand * (sign === 0 ? minSubnormal16 : -minSubnormal16);
-  return Math.pow(2, exponent - 15) * (sign === 0 ? 1 + significand * significandDenom16 : -1 - significand * significandDenom16);
+  var exponent = bytes >>> 10 & EXP_MASK16;
+  var significand = bytes & SIGNIFICAND_MASK16;
+  if (exponent === EXP_MASK16) return significand === 0 ? (sign === 0 ? Infinity : -Infinity) : NaN;
+  if (exponent === 0) return significand * (sign === 0 ? MIN_SUBNORMAL16 : -MIN_SUBNORMAL16);
+  return pow(2, exponent - 15) * (sign === 0 ? 1 + significand * SIGNIFICAND_DENOM16 : -1 - significand * SIGNIFICAND_DENOM16);
 }
 
 // eslint-disable-next-line es/no-typed-arrays -- safe

--- a/packages/core-js/modules/esnext.data-view.get-float16.js
+++ b/packages/core-js/modules/esnext.data-view.get-float16.js
@@ -9,14 +9,14 @@ var SIGNIFICAND_MASK16 = 1023; // 2 ** 10 - 1
 var MIN_SUBNORMAL16 = pow(2, -24); // 2 ** -10 * 2 ** -14
 var SIGNIFICAND_DENOM16 = 0.0009765625; // 2 ** -10
 
-function unpackFloat16(bytes) {
+var unpackFloat16 = function (bytes) {
   var sign = bytes >>> 15;
   var exponent = bytes >>> 10 & EXP_MASK16;
   var significand = bytes & SIGNIFICAND_MASK16;
   if (exponent === EXP_MASK16) return significand === 0 ? (sign === 0 ? Infinity : -Infinity) : NaN;
   if (exponent === 0) return significand * (sign === 0 ? MIN_SUBNORMAL16 : -MIN_SUBNORMAL16);
   return pow(2, exponent - 15) * (sign === 0 ? 1 + significand * SIGNIFICAND_DENOM16 : -1 - significand * SIGNIFICAND_DENOM16);
-}
+};
 
 // eslint-disable-next-line es/no-typed-arrays -- safe
 var getUint16 = uncurryThis(DataView.prototype.getUint16);

--- a/packages/core-js/modules/esnext.data-view.get-float16.js
+++ b/packages/core-js/modules/esnext.data-view.get-float16.js
@@ -2,15 +2,15 @@
 var $ = require('../internals/export');
 var uncurryThis = require('../internals/function-uncurry-this');
 
-const expMask16 = 31; // 2 ** 5 - 1
-const significandMask16 = 1023; // 2 ** 10 - 1
-const minSubnormal16 = Math.pow(2, -24); // 2 ** -10 * 2 ** -14
-const significandDenom16 = 0.0009765625; // 2 ** -10
+var expMask16 = 31; // 2 ** 5 - 1
+var significandMask16 = 1023; // 2 ** 10 - 1
+var minSubnormal16 = Math.pow(2, -24); // 2 ** -10 * 2 ** -14
+var significandDenom16 = 0.0009765625; // 2 ** -10
 
 function unpackFloat16(bytes) {
-  const sign = bytes >>> 15;
-  const exponent = bytes >>> 10 & expMask16;
-  const significand = bytes & significandMask16;
+  var sign = bytes >>> 15;
+  var exponent = bytes >>> 10 & expMask16;
+  var significand = bytes & significandMask16;
   if (exponent === expMask16) return significand === 0 ? (sign === 0 ? Infinity : -Infinity) : NaN;
   if (exponent === 0) return significand * (sign === 0 ? minSubnormal16 : -minSubnormal16);
   return Math.pow(2, exponent - 15) * (sign === 0 ? 1 + significand * significandDenom16 : -1 - significand * significandDenom16);

--- a/packages/core-js/modules/esnext.data-view.get-float16.js
+++ b/packages/core-js/modules/esnext.data-view.get-float16.js
@@ -2,15 +2,18 @@
 var $ = require('../internals/export');
 var uncurryThis = require('../internals/function-uncurry-this');
 
-const expMask16 = 2 ** 5 - 1, significandMask16 = 2 ** 10 - 1, minSubnormal16 = 2 ** -10 * 2 ** -14, significandDenom16 = 2 ** -10;
+const expMask16 = 31; // 2 ** 5 - 1
+const significandMask16 = 1023; // 2 ** 10 - 1
+const minSubnormal16 = Math.pow(2, -24); // 2 ** -10 * 2 ** -14
+const significandDenom16 = 0.0009765625; // 2 ** -10
 
 function unpackFloat16(bytes) {
-	const sign = bytes >>> 15;
-	const exponent = bytes >>> 10 & expMask16;
-	const significand = bytes & significandMask16;
-	if (exponent === expMask16) return significand === 0 ? (sign === 0 ? Infinity : -Infinity) : NaN;
-	if (exponent === 0) return significand * (sign === 0 ? minSubnormal16 : -minSubnormal16);
-	return 2 ** (exponent - 15) * (sign === 0 ? 1 + significand * significandDenom16 : -1 - significand * significandDenom16);
+  const sign = bytes >>> 15;
+  const exponent = bytes >>> 10 & expMask16;
+  const significand = bytes & significandMask16;
+  if (exponent === expMask16) return significand === 0 ? (sign === 0 ? Infinity : -Infinity) : NaN;
+  if (exponent === 0) return significand * (sign === 0 ? minSubnormal16 : -minSubnormal16);
+  return Math.pow(2, exponent - 15) * (sign === 0 ? 1 + significand * significandDenom16 : -1 - significand * significandDenom16);
 }
 
 // eslint-disable-next-line es/no-typed-arrays -- safe

--- a/packages/core-js/modules/esnext.data-view.set-float16.js
+++ b/packages/core-js/modules/esnext.data-view.set-float16.js
@@ -19,7 +19,7 @@ var MIN_NORMAL16 = 0.000061005353927612305; // (1 - 2 ** -11) * 2 ** -14
 var REC_MIN_SUBNORMAL16 = 16777216; // 2 ** 10 * 2 ** 14
 var REC_SIGNIFICAND_DENOM16 = 1024; // 2 ** 10;
 
-function packFloat16(value) {
+var packFloat16 = function (value) {
   // eslint-disable-next-line no-self-compare -- NaN check
   if (value !== value) return 0x7E00; // NaN
   if (value === 0) return (1 / value === -Infinity) << 15; // +0 or -0
@@ -42,7 +42,7 @@ function packFloat16(value) {
     return neg << 15 | exponent + 16 << 10;
   }
   return neg << 15 | exponent + 15 << 10 | significand;
-}
+};
 
 // eslint-disable-next-line es/no-typed-arrays -- safe
 var setUint16 = uncurryThis(DataView.prototype.setUint16);

--- a/packages/core-js/modules/esnext.data-view.set-float16.js
+++ b/packages/core-js/modules/esnext.data-view.set-float16.js
@@ -6,6 +6,8 @@ var toIndex = require('../internals/to-index');
 var f16round = require('../internals/math-f16round');
 
 var pow = Math.pow;
+var log = Math.log;
+var LN2 = Math.LN2;
 
 var EPSILON = 2.220446049250313e-16; // Number.EPSILON
 var INVERSE_EPSILON = 1 / EPSILON;
@@ -30,7 +32,7 @@ var packFloat16 = function (value) {
   if (value < MIN_NORMAL16) return neg << 15 | roundTiesToEven(value * REC_MIN_SUBNORMAL16); // subnormal
 
   // normal
-  var exponent = Math.log(value) / Math.LN2 | 0;
+  var exponent = log(value) / LN2 | 0;
   if (exponent === -15) {
     // we round from a value between 2 ** -15 * (1 + 1022/1024) (the largest subnormal) and 2 ** -14 * (1 + 0/1024) (the smallest normal)
     // to the latter (former impossible because of the subnormal check above)

--- a/packages/core-js/modules/esnext.data-view.set-float16.js
+++ b/packages/core-js/modules/esnext.data-view.set-float16.js
@@ -38,7 +38,7 @@ $({ target: 'DataView', proto: true }, {
   setFloat16: function setFloat16(byteOffset, value /* , littleEndian */) {
     aDataView(this);
     var offset = toIndex(byteOffset);
-    var bytes = packFloat16(f16round(value), 10, 2);
+    var bytes = packFloat16(f16round(value));
     return setUint16(this, offset, bytes[1] << 8 | bytes[0], arguments.length > 2 ? arguments[2] : false);
   }
 });

--- a/packages/core-js/modules/esnext.data-view.set-float16.js
+++ b/packages/core-js/modules/esnext.data-view.set-float16.js
@@ -39,6 +39,6 @@ $({ target: 'DataView', proto: true }, {
     aDataView(this);
     var offset = toIndex(byteOffset);
     var bytes = packFloat16(f16round(value));
-    return setUint16(this, offset, bytes[1] << 8 | bytes[0], arguments.length > 2 ? arguments[2] : false);
+    return setUint16(this, offset, bytes, arguments.length > 2 ? arguments[2] : false);
   }
 });

--- a/packages/core-js/modules/esnext.data-view.set-float16.js
+++ b/packages/core-js/modules/esnext.data-view.set-float16.js
@@ -3,8 +3,31 @@ var $ = require('../internals/export');
 var uncurryThis = require('../internals/function-uncurry-this');
 var aDataView = require('../internals/a-data-view');
 var toIndex = require('../internals/to-index');
-var packIEEE754 = require('../internals/ieee754').pack;
 var f16round = require('../internals/math-f16round');
+
+var EPSILON = 2.220446049250313e-16; // Number.EPSILON
+var INVERSE_EPSILON = 1 / EPSILON;
+
+var roundTiesToEven = function (n) {
+  return n + INVERSE_EPSILON - INVERSE_EPSILON;
+};
+
+const minInfinity16 = (2 - 2 ** -11) * 2 ** 15, minNormal16 = (1 - 2 ** -11) * 2 ** -14, recMinSubnormal16 = 2 ** 10 * 2 ** 14, recSignificandDenom16 = 2 ** 10;
+
+function packFloat16(value) {
+    if (Number.isNaN(value)) return 0x7e00; // NaN
+    if (value === 0) return (1 / value === -Infinity) << 15; // +0 or -0
+    const neg = value < 0;
+    if (neg) value = -value;
+    if (value >= minInfinity16) return neg << 15 | 0x7c00; // Infinity
+    if (value < minNormal16) return neg << 15 | roundTiesToEven(value * recMinSubnormal16); // subnormal
+    // normal
+    const exponent = Math.log2(value) | 0;
+    if (exponent === -15) return neg << 15 | recSignificandDenom16; // we round from a value between 2 ** -15 * (1 + 1022/1024) (the largest subnormal) and 2 ** -14 * (1 + 0/1024) (the smallest normal) to the latter (former impossible because of the subnormal check above)
+    const significand = roundTiesToEven((value * 2 ** -exponent - 1) * recSignificandDenom16);
+    if (significand === recSignificandDenom16) return neg << 15 | exponent + 16 << 10; // we round from a value between 2 ** n * (1 + 1023/1024) and 2 ** (n + 1) * (1 + 0/1024) to the latter
+    return neg << 15 | exponent + 15 << 10 | significand;
+}
 
 // eslint-disable-next-line es/no-typed-arrays -- safe
 var setUint16 = uncurryThis(DataView.prototype.setUint16);
@@ -15,7 +38,7 @@ $({ target: 'DataView', proto: true }, {
   setFloat16: function setFloat16(byteOffset, value /* , littleEndian */) {
     aDataView(this);
     var offset = toIndex(byteOffset);
-    var bytes = packIEEE754(f16round(value), 10, 2);
+    var bytes = packFloat16(f16round(value), 10, 2);
     return setUint16(this, offset, bytes[1] << 8 | bytes[0], arguments.length > 2 ? arguments[2] : false);
   }
 });

--- a/packages/core-js/modules/esnext.data-view.set-float16.js
+++ b/packages/core-js/modules/esnext.data-view.set-float16.js
@@ -12,21 +12,24 @@ var roundTiesToEven = function (n) {
   return n + INVERSE_EPSILON - INVERSE_EPSILON;
 };
 
-const minInfinity16 = (2 - 2 ** -11) * 2 ** 15, minNormal16 = (1 - 2 ** -11) * 2 ** -14, recMinSubnormal16 = 2 ** 10 * 2 ** 14, recSignificandDenom16 = 2 ** 10;
+const minInfinity16 = 65520; // (2 - 2 ** -11) * 2 ** 15
+const minNormal16 = 0.000061005353927612305; // (1 - 2 ** -11) * 2 ** -14
+const recMinSubnormal16 = 16777216; // 2 ** 10 * 2 ** 14
+const recSignificandDenom16 = 1024; // 2 ** 10;
 
 function packFloat16(value) {
-    if (Number.isNaN(value)) return 0x7e00; // NaN
-    if (value === 0) return (1 / value === -Infinity) << 15; // +0 or -0
-    const neg = value < 0;
-    if (neg) value = -value;
-    if (value >= minInfinity16) return neg << 15 | 0x7c00; // Infinity
-    if (value < minNormal16) return neg << 15 | roundTiesToEven(value * recMinSubnormal16); // subnormal
-    // normal
-    const exponent = Math.log2(value) | 0;
-    if (exponent === -15) return neg << 15 | recSignificandDenom16; // we round from a value between 2 ** -15 * (1 + 1022/1024) (the largest subnormal) and 2 ** -14 * (1 + 0/1024) (the smallest normal) to the latter (former impossible because of the subnormal check above)
-    const significand = roundTiesToEven((value * 2 ** -exponent - 1) * recSignificandDenom16);
-    if (significand === recSignificandDenom16) return neg << 15 | exponent + 16 << 10; // we round from a value between 2 ** n * (1 + 1023/1024) and 2 ** (n + 1) * (1 + 0/1024) to the latter
-    return neg << 15 | exponent + 15 << 10 | significand;
+  if (Number.isNaN(value)) return 0x7e00; // NaN
+  if (value === 0) return (1 / value === -Infinity) << 15; // +0 or -0
+  const neg = value < 0;
+  if (neg) value = -value;
+  if (value >= minInfinity16) return neg << 15 | 0x7c00; // Infinity
+  if (value < minNormal16) return neg << 15 | roundTiesToEven(value * recMinSubnormal16); // subnormal
+  // normal
+  const exponent = Math.log2(value) | 0;
+  if (exponent === -15) return neg << 15 | recSignificandDenom16; // we round from a value between 2 ** -15 * (1 + 1022/1024) (the largest subnormal) and 2 ** -14 * (1 + 0/1024) (the smallest normal) to the latter (former impossible because of the subnormal check above)
+  const significand = roundTiesToEven((value * Math.pow(2, -exponent) - 1) * recSignificandDenom16);
+  if (significand === recSignificandDenom16) return neg << 15 | exponent + 16 << 10; // we round from a value between 2 ** n * (1 + 1023/1024) and 2 ** (n + 1) * (1 + 0/1024) to the latter
+  return neg << 15 | exponent + 15 << 10 | significand;
 }
 
 // eslint-disable-next-line es/no-typed-arrays -- safe

--- a/packages/core-js/modules/esnext.data-view.set-float16.js
+++ b/packages/core-js/modules/esnext.data-view.set-float16.js
@@ -18,7 +18,7 @@ var recMinSubnormal16 = 16777216; // 2 ** 10 * 2 ** 14
 var recSignificandDenom16 = 1024; // 2 ** 10;
 
 function packFloat16(value) {
-  // eslint-disable-next-line no-self-compare
+  // eslint-disable-next-line no-self-compare -- NaN check
   if (value !== value) return 0x7E00; // NaN
   if (value === 0) return (1 / value === -Infinity) << 15; // +0 or -0
 

--- a/packages/core-js/modules/esnext.data-view.set-float16.js
+++ b/packages/core-js/modules/esnext.data-view.set-float16.js
@@ -29,12 +29,16 @@ function packFloat16(value) {
 
   // normal
   var exponent = Math.log(value) / Math.LN2 | 0;
-  // we round from a value between 2 ** -15 * (1 + 1022/1024) (the largest subnormal) and 2 ** -14 * (1 + 0/1024) (the smallest normal)
-  // to the latter (former impossible because of the subnormal check above)
-  if (exponent === -15) return neg << 15 | recSignificandDenom16;
+  if (exponent === -15) {
+    // we round from a value between 2 ** -15 * (1 + 1022/1024) (the largest subnormal) and 2 ** -14 * (1 + 0/1024) (the smallest normal)
+    // to the latter (former impossible because of the subnormal check above)
+    return neg << 15 | recSignificandDenom16;
+  }
   var significand = roundTiesToEven((value * Math.pow(2, -exponent) - 1) * recSignificandDenom16);
-  // we round from a value between 2 ** n * (1 + 1023/1024) and 2 ** (n + 1) * (1 + 0/1024) to the latter
-  if (significand === recSignificandDenom16) return neg << 15 | exponent + 16 << 10;
+  if (significand === recSignificandDenom16) {
+    // we round from a value between 2 ** n * (1 + 1023/1024) and 2 ** (n + 1) * (1 + 0/1024) to the latter
+    return neg << 15 | exponent + 16 << 10;
+  }
   return neg << 15 | exponent + 15 << 10 | significand;
 }
 

--- a/packages/core-js/modules/esnext.data-view.set-float16.js
+++ b/packages/core-js/modules/esnext.data-view.set-float16.js
@@ -12,22 +12,22 @@ var roundTiesToEven = function (n) {
   return n + INVERSE_EPSILON - INVERSE_EPSILON;
 };
 
-const minInfinity16 = 65520; // (2 - 2 ** -11) * 2 ** 15
-const minNormal16 = 0.000061005353927612305; // (1 - 2 ** -11) * 2 ** -14
-const recMinSubnormal16 = 16777216; // 2 ** 10 * 2 ** 14
-const recSignificandDenom16 = 1024; // 2 ** 10;
+var minInfinity16 = 65520; // (2 - 2 ** -11) * 2 ** 15
+var minNormal16 = 0.000061005353927612305; // (1 - 2 ** -11) * 2 ** -14
+var recMinSubnormal16 = 16777216; // 2 ** 10 * 2 ** 14
+var recSignificandDenom16 = 1024; // 2 ** 10;
 
 function packFloat16(value) {
   if (Number.isNaN(value)) return 0x7e00; // NaN
   if (value === 0) return (1 / value === -Infinity) << 15; // +0 or -0
-  const neg = value < 0;
+  var neg = value < 0;
   if (neg) value = -value;
   if (value >= minInfinity16) return neg << 15 | 0x7c00; // Infinity
   if (value < minNormal16) return neg << 15 | roundTiesToEven(value * recMinSubnormal16); // subnormal
   // normal
-  const exponent = Math.log2(value) | 0;
+  var exponent = Math.log2(value) | 0;
   if (exponent === -15) return neg << 15 | recSignificandDenom16; // we round from a value between 2 ** -15 * (1 + 1022/1024) (the largest subnormal) and 2 ** -14 * (1 + 0/1024) (the smallest normal) to the latter (former impossible because of the subnormal check above)
-  const significand = roundTiesToEven((value * Math.pow(2, -exponent) - 1) * recSignificandDenom16);
+  var significand = roundTiesToEven((value * Math.pow(2, -exponent) - 1) * recSignificandDenom16);
   if (significand === recSignificandDenom16) return neg << 15 | exponent + 16 << 10; // we round from a value between 2 ** n * (1 + 1023/1024) and 2 ** (n + 1) * (1 + 0/1024) to the latter
   return neg << 15 | exponent + 15 << 10 | significand;
 }


### PR DESCRIPTION
Hello!

Sorry I'm not really familiar with the code style of core-js -- feel free to modify this PR in any way.

This PR adds methods for packing/unpacking float16 values (instead of those from `internals/ieee754.js`) based on my code from [here](https://stackoverflow.com/a/78696004/20323848) (`roundTiesToEven` function taken from `internals/math-float-round.js`). They should be 100% IEEE754-compliant but are untested (would be great if you could help with that).

Packing is appoximately 15-20 times faster on my machine (running on an array of thousand values, ~16K ops/s vs ~900 ops/s) tested with the following JSBench code:
<details>
  <summary>Setup</summary>
  
  ```js
const N = 1E3;

const floats = [];
const results = [];

for (let i = 0; i < N; i++) {
	floats[i] = Math.random() * 2 ** (10 * Math.floor(Math.random()) - 20);
	results[i] = 0;
}

const minInfinity16 = (2 - 2 ** -11) * 2 ** 15, minNormal16 = (1 - 2 ** -11) * 2 ** -14, recMinSubnormal16 = 2 ** 10 * 2 ** 14, recSignificandDenom16 = 2 ** 10;

var EPSILON = 2.220446049250313e-16; // Number.EPSILON
var INVERSE_EPSILON = 1 / EPSILON;

var roundTiesToEven = function (n) {
  return n + INVERSE_EPSILON - INVERSE_EPSILON;
};

function toFloat16(value) {
    if (Number.isNaN(value)) return 0x7e00; // NaN
    if (value === 0) return (1 / value === -Infinity) << 15; // +0 or -0
    const neg = value < 0;
    if (neg) value = -value;
    if (value >= minInfinity16) return neg << 15 | 0x7c00; // Infinity
    if (value < minNormal16) return neg << 15 | roundTiesToEven(value * recMinSubnormal16); // subnormal
    // normal
    const exponent = Math.log2(value) | 0;
    if (exponent === -15) return neg << 15 | recSignificandDenom16; // we round from a value between 2 ** -15 * (1 + 1022/1024) (the largest subnormal) and 2 ** -14 * (1 + 0/1024) (the smallest normal) to the latter (former impossible because of the subnormal check above)
    const significand = roundTiesToEven((value * 2 ** -exponent - 1) * recSignificandDenom16);
    if (significand === recSignificandDenom16) return neg << 15 | exponent + 16 << 10; // we round from a value between 2 ** n * (1 + 1023/1024) and 2 ** (n + 1) * (1 + 0/1024) to the latter
    return neg << 15 | exponent + 15 << 10 | significand;
}

var $Array = Array;
var abs = Math.abs;
var pow = Math.pow;
var floor = Math.floor;
var log = Math.log;
var LN2 = Math.LN2;

var pack = function (number, mantissaLength, bytes) {
  var buffer = $Array(bytes);
  var exponentLength = bytes * 8 - mantissaLength - 1;
  var eMax = (1 << exponentLength) - 1;
  var eBias = eMax >> 1;
  var rt = mantissaLength === 23 ? pow(2, -24) - pow(2, -77) : 0;
  var sign = number < 0 || number === 0 && 1 / number < 0 ? 1 : 0;
  var index = 0;
  var exponent, mantissa, c;
  number = abs(number);
  // eslint-disable-next-line no-self-compare -- NaN check
  if (number !== number || number === Infinity) {
    // eslint-disable-next-line no-self-compare -- NaN check
    mantissa = number !== number ? 1 : 0;
    exponent = eMax;
  } else {
    exponent = floor(log(number) / LN2);
    c = pow(2, -exponent);
    if (number * c < 1) {
      exponent--;
      c *= 2;
    }
    if (exponent + eBias >= 1) {
      number += rt / c;
    } else {
      number += rt * pow(2, 1 - eBias);
    }
    if (number * c >= 2) {
      exponent++;
      c /= 2;
    }
    if (exponent + eBias >= eMax) {
      mantissa = 0;
      exponent = eMax;
    } else if (exponent + eBias >= 1) {
      mantissa = (number * c - 1) * pow(2, mantissaLength);
      exponent += eBias;
    } else {
      mantissa = number * pow(2, eBias - 1) * pow(2, mantissaLength);
      exponent = 0;
    }
  }
  while (mantissaLength >= 8) {
    buffer[index++] = mantissa & 255;
    mantissa /= 256;
    mantissaLength -= 8;
  }
  exponent = exponent << mantissaLength | mantissa;
  exponentLength += mantissaLength;
  while (exponentLength > 0) {
    buffer[index++] = exponent & 255;
    exponent /= 256;
    exponentLength -= 8;
  }
  buffer[index - 1] |= sign * 128;
  return buffer;
};
```
</details>

<details>
  <summary>Original implementation case</summary>
  
  ```js
  for (let i = 0; i < N; i++) results[i] = pack(floats[i], 10, 2);
  ```
  
</details>

<details>
  <summary>New implementation case</summary>
  
  ```js
  for (let i = 0; i < N; i++) results[i] = toFloat16(floats[i]);
  ```
  
</details>