### PR TITLE
Check correct behavior of Uint8Array.setFromBase64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Don't call well-known Symbol methods for RegExp on primitive values [tc39/ecma262#3009](https://github.com/tc39/ecma262/pull/3009)
 - Added 'intersect' support for `targets.esmodules` (Babel v7 behavior)
 - Fixed handling of `targets.esmodules: true` (Babel v7 behavior)
+- Added workaround for the `Uint8Array.prototype.setFromBase64` [bug](https://bugs.webkit.org/show_bug.cgi?id=290829) in a Linux build of WebKit
 - Compat data improvements:
   - [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) features disabled (again) in V8 ~ Chromium 135 and re-added in 136
   - [`RegExp.escape`](https://github.com/tc39/proposal-regex-escaping) marked as [shipped from V8 ~ Chromium 136](https://issues.chromium.org/issues/353856236#comment17)

--- a/packages/core-js-compat/src/data.mjs
+++ b/packages/core-js-compat/src/data.mjs
@@ -2743,7 +2743,10 @@ export const data = {
   'esnext.uint8-array.set-from-base64': {
     bun: '1.1.22',
     firefox: '133',
-    safari: '18.2',
+    // Uint8Array.prototype.setFromBase64 doesn't write chunks before invalid data
+    // https://bugs.webkit.org/show_bug.cgi?id=290829
+    safari: false,  // '18.2'
+    ios: '18.2',
   },
   'esnext.uint8-array.set-from-hex': {
     bun: '1.1.22',

--- a/packages/core-js/modules/esnext.uint8-array.set-from-base64.js
+++ b/packages/core-js/modules/esnext.uint8-array.set-from-base64.js
@@ -6,9 +6,19 @@ var anUint8Array = require('../internals/an-uint8-array');
 
 var Uint8Array = globalThis.Uint8Array;
 
+var INCORRECT_BEHAVIOR_OR_DOESNT_EXISTS = !Uint8Array || !Uint8Array.prototype.setFromBase64 || !(function () {
+  var target = new Uint8Array([255, 255, 255, 255, 255]);
+  try {
+    target.setFromBase64('MjYyZg===');
+  } catch (error) {
+    return target[0] === 50 && target[1] === 54 && target[2] === 50 && target[3] === 255 && target[4] === 255;
+  }
+  return false;
+})();
+
 // `Uint8Array.prototype.setFromBase64` method
 // https://github.com/tc39/proposal-arraybuffer-base64
-if (Uint8Array) $({ target: 'Uint8Array', proto: true }, {
+if (Uint8Array) $({ target: 'Uint8Array', proto: true, forced: INCORRECT_BEHAVIOR_OR_DOESNT_EXISTS }, {
   setFromBase64: function setFromBase64(string /* , options */) {
     anUint8Array(this);
 

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -1917,7 +1917,13 @@ GLOBAL.tests = {
     return Uint8Array.fromHex;
   },
   'esnext.uint8-array.set-from-base64': function () {
-    return Uint8Array.prototype.setFromBase64;
+    var target = new Uint8Array([255, 255, 255, 255, 255]);
+    try {
+      target.setFromBase64('MjYyZg===');
+    } catch (error) {
+      return target[0] === 50 && target[1] === 54 && target[2] === 50 && target[3] === 255 && target[4] === 255;
+    }
+    return false;
   },
   'esnext.uint8-array.set-from-hex': function () {
     return Uint8Array.prototype.setFromHex;


### PR DESCRIPTION
Workaround for bug [290829](https://bugs.webkit.org/show_bug.cgi?id=290829) in a Linux build of WebKit