### PR TITLE
Close sync iterables when they yield rejected promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - `Iterator.prototype.some`
   - `Iterator.prototype.take`
 - Fixed missing forced replacement of `AsyncIterator` helpers
+- Added closing of sync iterator when async wrapper yields a rejection [tc39/ecma262#2600](https://github.com/tc39/ecma262/pull/2600)
 - Compat data improvements:
   - [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) features disabled (again) in V8 ~ Chromium 135 and re-added in 136
   - [`RegExp.escape`](https://github.com/tc39/proposal-regex-escaping) marked as [shipped from V8 ~ Chromium 136](https://issues.chromium.org/issues/353856236#comment17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@
   - `Iterator.prototype.some`
   - `Iterator.prototype.take`
 - Fixed missing forced replacement of `AsyncIterator` helpers
-- Added closing of sync iterator when async wrapper yields a rejection [tc39/ecma262#2600](https://github.com/tc39/ecma262/pull/2600)
+- Added closing of sync iterator when async wrapper yields a rejection [tc39/ecma262#2600](https://github.com/tc39/ecma262/pull/2600). Affected methods:
+  - `Array.prototype.fromAsync` (due to the lack of async feature detection capability - temporarily, only in own core-js implementation)
+  - `AsyncIterator.prototype.from`
+  - `Iterator.prototype.toAsync`
 - Compat data improvements:
   - [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) features disabled (again) in V8 ~ Chromium 135 and re-added in 136
   - [`RegExp.escape`](https://github.com/tc39/proposal-regex-escaping) marked as [shipped from V8 ~ Chromium 136](https://issues.chromium.org/issues/353856236#comment17)

--- a/packages/core-js/internals/async-from-sync-iterator.js
+++ b/packages/core-js/internals/async-from-sync-iterator.js
@@ -21,10 +21,12 @@ var asyncFromSyncIteratorContinuation = function (result, resolve, reject, syncI
   Promise.resolve(result.value).then(function (value) {
     resolve(createIterResultObject(value, done));
   }, function (error) {
-    try {
-      if (!done && closeOnRejection) iteratorClose(syncIterator, 'throw', error);
-    } catch (error2) {
-      error = error2;
+    if (!done && closeOnRejection) {
+      try {
+        iteratorClose(syncIterator, 'throw', error);
+      } catch (error2) {
+        error = error2;
+      }
     }
 
     reject(error);

--- a/packages/core-js/internals/async-from-sync-iterator.js
+++ b/packages/core-js/internals/async-from-sync-iterator.js
@@ -5,6 +5,7 @@ var create = require('../internals/object-create');
 var getMethod = require('../internals/get-method');
 var defineBuiltIns = require('../internals/define-built-ins');
 var InternalStateModule = require('../internals/internal-state');
+var iteratorClose = require('../internals/iterator-close');
 var getBuiltIn = require('../internals/get-built-in');
 var AsyncIteratorPrototype = require('../internals/async-iterator-prototype');
 var createIterResultObject = require('../internals/create-iter-result-object');
@@ -15,11 +16,19 @@ var ASYNC_FROM_SYNC_ITERATOR = 'AsyncFromSyncIterator';
 var setInternalState = InternalStateModule.set;
 var getInternalState = InternalStateModule.getterFor(ASYNC_FROM_SYNC_ITERATOR);
 
-var asyncFromSyncIteratorContinuation = function (result, resolve, reject) {
+var asyncFromSyncIteratorContinuation = function (result, resolve, reject, syncIterator, closeOnRejection) {
   var done = result.done;
   Promise.resolve(result.value).then(function (value) {
     resolve(createIterResultObject(value, done));
-  }, reject);
+  }, function (error) {
+    try {
+      if (!done && closeOnRejection) iteratorClose(syncIterator, 'throw', error);
+    } catch (error2) {
+      error = error2;
+    }
+
+    reject(error);
+  });
 };
 
 var AsyncFromSyncIterator = function AsyncIterator(iteratorRecord) {
@@ -32,7 +41,7 @@ AsyncFromSyncIterator.prototype = defineBuiltIns(create(AsyncIteratorPrototype),
     var state = getInternalState(this);
     return new Promise(function (resolve, reject) {
       var result = anObject(call(state.next, state.iterator));
-      asyncFromSyncIteratorContinuation(result, resolve, reject);
+      asyncFromSyncIteratorContinuation(result, resolve, reject, state.iterator, true);
     });
   },
   'return': function () {
@@ -41,7 +50,7 @@ AsyncFromSyncIterator.prototype = defineBuiltIns(create(AsyncIteratorPrototype),
       var $return = getMethod(iterator, 'return');
       if ($return === undefined) return resolve(createIterResultObject(undefined, true));
       var result = anObject(call($return, iterator));
-      asyncFromSyncIteratorContinuation(result, resolve, reject);
+      asyncFromSyncIteratorContinuation(result, resolve, reject, iterator);
     });
   }
 });

--- a/tests/unit-global/esnext.array.from-async.js
+++ b/tests/unit-global/esnext.array.from-async.js
@@ -91,7 +91,7 @@ QUnit.test('Array.fromAsync', assert => {
   }, error => {
     assert.true(error instanceof TypeError);
   });
-  /* Tests are temporarily disabled due to the lack of proper async feature detection.
+  /* Tests are temporarily disabled due to the lack of proper async feature detection in native implementations.
   .then(() => {
     return fromAsync(Iterator.from(closableIterator), () => { throw 42; });
   }).then(() => {

--- a/tests/unit-global/esnext.array.from-async.js
+++ b/tests/unit-global/esnext.array.from-async.js
@@ -1,4 +1,4 @@
-import { createAsyncIterable, createIterable, createIterator } from '../helpers/helpers.js';
+import { createAsyncIterable, createIterable/* , createIterator */ } from '../helpers/helpers.js';
 import { STRICT_THIS } from '../helpers/constants.js';
 
 QUnit.test('Array.fromAsync', assert => {
@@ -21,9 +21,9 @@ QUnit.test('Array.fromAsync', assert => {
 
   function C() { /* empty */ }
 
-  const closableIterator = createIterator([1], {
-    return() { this.closed = true; return { value: undefined, done: true }; },
-  });
+  // const closableIterator = createIterator([1], {
+  //   return() { this.closed = true; return { value: undefined, done: true }; },
+  // });
 
   return fromAsync(createAsyncIterable([1, 2, 3]), it => it ** 2).then(it => {
     assert.arrayEqual(it, [1, 4, 9], 'async iterable and mapfn');
@@ -90,12 +90,14 @@ QUnit.test('Array.fromAsync', assert => {
     assert.avoid();
   }, error => {
     assert.true(error instanceof TypeError);
-  }).then(() => {
+  });
+  /* Tests are temporarily disabled due to the lack of proper async feature detection.
+  .then(() => {
     return fromAsync(Iterator.from(closableIterator), () => { throw 42; });
   }).then(() => {
     assert.avoid();
   }, error => {
     assert.same(error, 42, 'rejection on a callback error');
     assert.true(closableIterator.closed, 'doesn\'t close sync iterator on promise rejection');
-  });
+  }); */
 });

--- a/tests/unit-global/esnext.async-iterator.from.js
+++ b/tests/unit-global/esnext.async-iterator.from.js
@@ -1,4 +1,4 @@
-import ITERATOR from 'core-js-pure/es/symbol/iterator';
+// import ITERATOR from 'core-js-pure/es/symbol/iterator';
 
 const { assign, create } = Object;
 
@@ -24,26 +24,28 @@ QUnit.test('AsyncIterator.from', assert => {
   assert.throws(() => from(undefined), TypeError);
   assert.throws(() => from(null), TypeError);
 
-  const closableIterator = {
-    closed: false,
-    [ITERATOR]() { return this; },
-    next() {
-      return { value: Promise.reject(42), done: false };
-    },
-    return() {
-      this.closed = true;
-      return { value: undefined, done: true };
-    },
-  };
+  // const closableIterator = {
+  //   closed: false,
+  //   [ITERATOR]() { return this; },
+  //   next() {
+  //     return { value: Promise.reject(42), done: false };
+  //   },
+  //   return() {
+  //     this.closed = true;
+  //     return { value: undefined, done: true };
+  //   },
+  // };
 
   return AsyncIterator.from([1, Promise.resolve(2), 3]).toArray().then(result => {
     assert.arrayEqual(result, [1, 2, 3], 'unwrap promises');
-  }).then(() => {
+  });
+  /* Tests are temporarily disabled due to the lack of proper async feature detection.
+  .then(() => {
     return from(Iterator.from(closableIterator)).toArray();
   }).then(() => {
     assert.avoid();
   }, error => {
     assert.same(error, 42, 'rejection on a callback error');
     assert.true(closableIterator.closed, 'doesn\'t close sync iterator on promise rejection');
-  });
+  }); */
 });

--- a/tests/unit-global/esnext.async-iterator.from.js
+++ b/tests/unit-global/esnext.async-iterator.from.js
@@ -1,4 +1,4 @@
-// import ITERATOR from 'core-js-pure/es/symbol/iterator';
+import ITERATOR from 'core-js-pure/es/symbol/iterator';
 
 const { assign, create } = Object;
 
@@ -24,22 +24,21 @@ QUnit.test('AsyncIterator.from', assert => {
   assert.throws(() => from(undefined), TypeError);
   assert.throws(() => from(null), TypeError);
 
-  // const closableIterator = {
-  //   closed: false,
-  //   [ITERATOR]() { return this; },
-  //   next() {
-  //     return { value: Promise.reject(42), done: false };
-  //   },
-  //   return() {
-  //     this.closed = true;
-  //     return { value: undefined, done: true };
-  //   },
-  // };
+  const closableIterator = {
+    closed: false,
+    [ITERATOR]() { return this; },
+    next() {
+      return { value: Promise.reject(42), done: false };
+    },
+    return() {
+      this.closed = true;
+      return { value: undefined, done: true };
+    },
+  };
 
   return AsyncIterator.from([1, Promise.resolve(2), 3]).toArray().then(result => {
     assert.arrayEqual(result, [1, 2, 3], 'unwrap promises');
-  });
-  /* Tests are temporarily disabled due to the lack of proper async feature detection.
+  })
   .then(() => {
     return from(Iterator.from(closableIterator)).toArray();
   }).then(() => {
@@ -47,5 +46,5 @@ QUnit.test('AsyncIterator.from', assert => {
   }, error => {
     assert.same(error, 42, 'rejection on a callback error');
     assert.true(closableIterator.closed, 'doesn\'t close sync iterator on promise rejection');
-  }); */
+  });
 });

--- a/tests/unit-global/esnext.async-iterator.from.js
+++ b/tests/unit-global/esnext.async-iterator.from.js
@@ -38,8 +38,7 @@ QUnit.test('AsyncIterator.from', assert => {
 
   return AsyncIterator.from([1, Promise.resolve(2), 3]).toArray().then(result => {
     assert.arrayEqual(result, [1, 2, 3], 'unwrap promises');
-  })
-  .then(() => {
+  }).then(() => {
     return from(Iterator.from(closableIterator)).toArray();
   }).then(() => {
     assert.avoid();

--- a/tests/unit-global/esnext.iterator.to-async.js
+++ b/tests/unit-global/esnext.iterator.to-async.js
@@ -1,5 +1,5 @@
 import { STRICT } from '../helpers/constants.js';
-import ITERATOR from 'core-js-pure/es/symbol/iterator';
+// import ITERATOR from 'core-js-pure/es/symbol/iterator';
 
 QUnit.test('Iterator#toAsync', assert => {
   const { toAsync } = Iterator.prototype;
@@ -15,28 +15,31 @@ QUnit.test('Iterator#toAsync', assert => {
     assert.throws(() => toAsync.call(null), TypeError);
   }
 
-  const closableIterator = {
-    closed: false,
-    [ITERATOR]() { return this; },
-    next() {
-      return { value: Promise.reject(42), done: false };
-    },
-    return() {
-      this.closed = true;
-      return { value: undefined, done: true };
-    },
-  };
+  // const closableIterator = {
+  //   closed: false,
+  //   [ITERATOR]() { return this; },
+  //   next() {
+  //     return { value: Promise.reject(42), done: false };
+  //   },
+  //   return() {
+  //     this.closed = true;
+  //     return { value: undefined, done: true };
+  //   },
+  // };
 
   return [1, 2, 3].values().toAsync().map(it => Promise.resolve(it)).toArray().then(it => {
     assert.arrayEqual(it, [1, 2, 3]);
     return new Set([1, 2, 3]).values().toAsync().map(el => Promise.resolve(el)).toArray();
   }).then(it => {
     assert.arrayEqual(it, [1, 2, 3]);
+  });
+  /* Tests are temporarily disabled due to the lack of proper async feature detection.
+  .then(() => {
     return Iterator.from(closableIterator).toAsync().toArray();
   }).then(() => {
     assert.avoid();
   }, error => {
     assert.same(error, 42, 'rejection on a callback error');
     assert.true(closableIterator.closed, 'doesn\'t close sync iterator on promise rejection');
-  });
+  }); */
 });

--- a/tests/unit-global/esnext.iterator.to-async.js
+++ b/tests/unit-global/esnext.iterator.to-async.js
@@ -1,4 +1,5 @@
 import { STRICT } from '../helpers/constants.js';
+import ITERATOR from 'core-js-pure/es/symbol/iterator';
 
 QUnit.test('Iterator#toAsync', assert => {
   const { toAsync } = Iterator.prototype;
@@ -14,10 +15,28 @@ QUnit.test('Iterator#toAsync', assert => {
     assert.throws(() => toAsync.call(null), TypeError);
   }
 
+  const closableIterator = {
+    closed: false,
+    [ITERATOR]() { return this; },
+    next() {
+      return { value: Promise.reject(42), done: false };
+    },
+    return() {
+      this.closed = true;
+      return { value: undefined, done: true };
+    },
+  };
+
   return [1, 2, 3].values().toAsync().map(it => Promise.resolve(it)).toArray().then(it => {
     assert.arrayEqual(it, [1, 2, 3]);
     return new Set([1, 2, 3]).values().toAsync().map(el => Promise.resolve(el)).toArray();
   }).then(it => {
     assert.arrayEqual(it, [1, 2, 3]);
+    return Iterator.from(closableIterator).toAsync().toArray();
+  }).then(() => {
+    assert.avoid();
+  }, error => {
+    assert.same(error, 42, 'rejection on a callback error');
+    assert.true(closableIterator.closed, 'doesn\'t close sync iterator on promise rejection');
   });
 });

--- a/tests/unit-global/esnext.iterator.to-async.js
+++ b/tests/unit-global/esnext.iterator.to-async.js
@@ -1,5 +1,5 @@
 import { STRICT } from '../helpers/constants.js';
-// import ITERATOR from 'core-js-pure/es/symbol/iterator';
+import ITERATOR from 'core-js-pure/es/symbol/iterator';
 
 QUnit.test('Iterator#toAsync', assert => {
   const { toAsync } = Iterator.prototype;
@@ -15,31 +15,29 @@ QUnit.test('Iterator#toAsync', assert => {
     assert.throws(() => toAsync.call(null), TypeError);
   }
 
-  // const closableIterator = {
-  //   closed: false,
-  //   [ITERATOR]() { return this; },
-  //   next() {
-  //     return { value: Promise.reject(42), done: false };
-  //   },
-  //   return() {
-  //     this.closed = true;
-  //     return { value: undefined, done: true };
-  //   },
-  // };
+  const closableIterator = {
+    closed: false,
+    [ITERATOR]() { return this; },
+    next() {
+      return { value: Promise.reject(42), done: false };
+    },
+    return() {
+      this.closed = true;
+      return { value: undefined, done: true };
+    },
+  };
 
   return [1, 2, 3].values().toAsync().map(it => Promise.resolve(it)).toArray().then(it => {
     assert.arrayEqual(it, [1, 2, 3]);
     return new Set([1, 2, 3]).values().toAsync().map(el => Promise.resolve(el)).toArray();
   }).then(it => {
     assert.arrayEqual(it, [1, 2, 3]);
-  });
-  /* Tests are temporarily disabled due to the lack of proper async feature detection.
-  .then(() => {
+  }).then(() => {
     return Iterator.from(closableIterator).toAsync().toArray();
   }).then(() => {
     assert.avoid();
   }, error => {
     assert.same(error, 42, 'rejection on a callback error');
     assert.true(closableIterator.closed, 'doesn\'t close sync iterator on promise rejection');
-  }); */
+  });
 });

--- a/tests/unit-pure/esnext.array.from-async.js
+++ b/tests/unit-pure/esnext.array.from-async.js
@@ -91,7 +91,7 @@ QUnit.test('Array.fromAsync', assert => {
   }, error => {
     assert.true(error instanceof TypeError);
   });
-  /* Tests are temporarily disabled due to the lack of proper async feature detection.
+  /* Tests are temporarily disabled due to the lack of proper async feature detection in native implementations.
   .then(() => {
     return fromAsync(Iterator.from(closableIterator), () => { throw 42; });
   }).then(() => {

--- a/tests/unit-pure/esnext.array.from-async.js
+++ b/tests/unit-pure/esnext.array.from-async.js
@@ -1,8 +1,9 @@
-import { createAsyncIterable, createIterable } from '../helpers/helpers.js';
+import { createAsyncIterable, createIterable, createIterator } from '../helpers/helpers.js';
 import { STRICT_THIS } from '../helpers/constants.js';
 
 import Promise from 'core-js-pure/es/promise';
 import fromAsync from 'core-js-pure/actual/array/from-async';
+import Iterator from 'core-js-pure/actual/iterator';
 
 QUnit.test('Array.fromAsync', assert => {
   assert.isFunction(fromAsync);
@@ -19,6 +20,10 @@ QUnit.test('Array.fromAsync', assert => {
   assert.same(counter, 1, 'proper number of constructor calling');
 
   function C() { /* empty */ }
+
+  const closableIterator = createIterator([1], {
+    return() { this.closed = true; return { value: undefined, done: true }; },
+  });
 
   return fromAsync(createAsyncIterable([1, 2, 3]), it => it ** 2).then(it => {
     assert.arrayEqual(it, [1, 4, 9], 'async iterable and mapfn');
@@ -85,5 +90,12 @@ QUnit.test('Array.fromAsync', assert => {
     assert.avoid();
   }, error => {
     assert.true(error instanceof TypeError);
+  }).then(() => {
+    return fromAsync(Iterator.from(closableIterator), () => { throw 42; });
+  }).then(() => {
+    assert.avoid();
+  }, error => {
+    assert.same(error, 42, 'rejection on a callback error');
+    assert.true(closableIterator.closed, 'doesn\'t close sync iterator on promise rejection');
   });
 });

--- a/tests/unit-pure/esnext.array.from-async.js
+++ b/tests/unit-pure/esnext.array.from-async.js
@@ -1,9 +1,9 @@
-import { createAsyncIterable, createIterable, createIterator } from '../helpers/helpers.js';
+import { createAsyncIterable, createIterable/* , createIterator */ } from '../helpers/helpers.js';
 import { STRICT_THIS } from '../helpers/constants.js';
 
 import Promise from 'core-js-pure/es/promise';
 import fromAsync from 'core-js-pure/actual/array/from-async';
-import Iterator from 'core-js-pure/actual/iterator';
+// import Iterator from 'core-js-pure/actual/iterator';
 
 QUnit.test('Array.fromAsync', assert => {
   assert.isFunction(fromAsync);
@@ -21,9 +21,9 @@ QUnit.test('Array.fromAsync', assert => {
 
   function C() { /* empty */ }
 
-  const closableIterator = createIterator([1], {
-    return() { this.closed = true; return { value: undefined, done: true }; },
-  });
+  // const closableIterator = createIterator([1], {
+  //   return() { this.closed = true; return { value: undefined, done: true }; },
+  // });
 
   return fromAsync(createAsyncIterable([1, 2, 3]), it => it ** 2).then(it => {
     assert.arrayEqual(it, [1, 4, 9], 'async iterable and mapfn');
@@ -90,12 +90,14 @@ QUnit.test('Array.fromAsync', assert => {
     assert.avoid();
   }, error => {
     assert.true(error instanceof TypeError);
-  }).then(() => {
+  });
+  /* Tests are temporarily disabled due to the lack of proper async feature detection.
+  .then(() => {
     return fromAsync(Iterator.from(closableIterator), () => { throw 42; });
   }).then(() => {
     assert.avoid();
   }, error => {
     assert.same(error, 42, 'rejection on a callback error');
     assert.true(closableIterator.closed, 'doesn\'t close sync iterator on promise rejection');
-  });
+  }); */
 });

--- a/tests/unit-pure/esnext.async-iterator.from.js
+++ b/tests/unit-pure/esnext.async-iterator.from.js
@@ -2,7 +2,9 @@ import Promise from 'core-js-pure/es/promise';
 import assign from 'core-js-pure/es/object/assign';
 import create from 'core-js-pure/es/object/create';
 import values from 'core-js-pure/es/array/values';
+import ITERATOR from 'core-js-pure/es/symbol/iterator';
 import AsyncIterator from 'core-js-pure/actual/async-iterator';
+import Iterator from 'core-js-pure/actual/iterator';
 
 QUnit.test('AsyncIterator.from', assert => {
   const { from } = AsyncIterator;
@@ -23,7 +25,26 @@ QUnit.test('AsyncIterator.from', assert => {
   assert.throws(() => from(undefined), TypeError);
   assert.throws(() => from(null), TypeError);
 
+  const closableIterator = {
+    closed: false,
+    [ITERATOR]() { return this; },
+    next() {
+      return { value: Promise.reject(42), done: false };
+    },
+    return() {
+      this.closed = true;
+      return { value: undefined, done: true };
+    },
+  };
+
   return AsyncIterator.from([1, Promise.resolve(2), 3]).toArray().then(result => {
     assert.arrayEqual(result, [1, 2, 3], 'unwrap promises');
+  }).then(() => {
+    return from(Iterator.from(closableIterator)).toArray();
+  }).then(() => {
+    assert.avoid();
+  }, error => {
+    assert.same(error, 42, 'rejection on a callback error');
+    assert.true(closableIterator.closed, 'doesn\'t close sync iterator on promise rejection');
   });
 });

--- a/tests/unit-pure/esnext.async-iterator.from.js
+++ b/tests/unit-pure/esnext.async-iterator.from.js
@@ -2,9 +2,9 @@ import Promise from 'core-js-pure/es/promise';
 import assign from 'core-js-pure/es/object/assign';
 import create from 'core-js-pure/es/object/create';
 import values from 'core-js-pure/es/array/values';
-// import ITERATOR from 'core-js-pure/es/symbol/iterator';
+import ITERATOR from 'core-js-pure/es/symbol/iterator';
 import AsyncIterator from 'core-js-pure/actual/async-iterator';
-// import Iterator from 'core-js-pure/actual/iterator';
+import Iterator from 'core-js-pure/actual/iterator';
 
 QUnit.test('AsyncIterator.from', assert => {
   const { from } = AsyncIterator;
@@ -25,28 +25,26 @@ QUnit.test('AsyncIterator.from', assert => {
   assert.throws(() => from(undefined), TypeError);
   assert.throws(() => from(null), TypeError);
 
-  // const closableIterator = {
-  //   closed: false,
-  //   [ITERATOR]() { return this; },
-  //   next() {
-  //     return { value: Promise.reject(42), done: false };
-  //   },
-  //   return() {
-  //     this.closed = true;
-  //     return { value: undefined, done: true };
-  //   },
-  // };
+  const closableIterator = {
+    closed: false,
+    [ITERATOR]() { return this; },
+    next() {
+      return { value: Promise.reject(42), done: false };
+    },
+    return() {
+      this.closed = true;
+      return { value: undefined, done: true };
+    },
+  };
 
   return AsyncIterator.from([1, Promise.resolve(2), 3]).toArray().then(result => {
     assert.arrayEqual(result, [1, 2, 3], 'unwrap promises');
-  });
-  /* Tests are temporarily disabled due to the lack of proper async feature detection.
-  .then(() => {
+  }).then(() => {
     return from(Iterator.from(closableIterator)).toArray();
   }).then(() => {
     assert.avoid();
   }, error => {
     assert.same(error, 42, 'rejection on a callback error');
     assert.true(closableIterator.closed, 'doesn\'t close sync iterator on promise rejection');
-  }); */
+  });
 });

--- a/tests/unit-pure/esnext.async-iterator.from.js
+++ b/tests/unit-pure/esnext.async-iterator.from.js
@@ -2,9 +2,9 @@ import Promise from 'core-js-pure/es/promise';
 import assign from 'core-js-pure/es/object/assign';
 import create from 'core-js-pure/es/object/create';
 import values from 'core-js-pure/es/array/values';
-import ITERATOR from 'core-js-pure/es/symbol/iterator';
+// import ITERATOR from 'core-js-pure/es/symbol/iterator';
 import AsyncIterator from 'core-js-pure/actual/async-iterator';
-import Iterator from 'core-js-pure/actual/iterator';
+// import Iterator from 'core-js-pure/actual/iterator';
 
 QUnit.test('AsyncIterator.from', assert => {
   const { from } = AsyncIterator;
@@ -25,26 +25,28 @@ QUnit.test('AsyncIterator.from', assert => {
   assert.throws(() => from(undefined), TypeError);
   assert.throws(() => from(null), TypeError);
 
-  const closableIterator = {
-    closed: false,
-    [ITERATOR]() { return this; },
-    next() {
-      return { value: Promise.reject(42), done: false };
-    },
-    return() {
-      this.closed = true;
-      return { value: undefined, done: true };
-    },
-  };
+  // const closableIterator = {
+  //   closed: false,
+  //   [ITERATOR]() { return this; },
+  //   next() {
+  //     return { value: Promise.reject(42), done: false };
+  //   },
+  //   return() {
+  //     this.closed = true;
+  //     return { value: undefined, done: true };
+  //   },
+  // };
 
   return AsyncIterator.from([1, Promise.resolve(2), 3]).toArray().then(result => {
     assert.arrayEqual(result, [1, 2, 3], 'unwrap promises');
-  }).then(() => {
+  });
+  /* Tests are temporarily disabled due to the lack of proper async feature detection.
+  .then(() => {
     return from(Iterator.from(closableIterator)).toArray();
   }).then(() => {
     assert.avoid();
   }, error => {
     assert.same(error, 42, 'rejection on a callback error');
     assert.true(closableIterator.closed, 'doesn\'t close sync iterator on promise rejection');
-  });
+  }); */
 });

--- a/tests/unit-pure/esnext.iterator.to-async.js
+++ b/tests/unit-pure/esnext.iterator.to-async.js
@@ -2,7 +2,7 @@ import { STRICT } from '../helpers/constants.js';
 
 import Promise from 'core-js-pure/es/promise';
 import Set from 'core-js-pure/es/set';
-// import ITERATOR from 'core-js-pure/es/symbol/iterator';
+import ITERATOR from 'core-js-pure/es/symbol/iterator';
 import Iterator from 'core-js-pure/actual/iterator';
 import 'core-js-pure/actual/async-iterator';
 
@@ -17,31 +17,29 @@ QUnit.test('Iterator#toAsync', assert => {
     assert.throws(() => toAsync.call(null), TypeError);
   }
 
-  // const closableIterator = {
-  //   closed: false,
-  //   [ITERATOR]() { return this; },
-  //   next() {
-  //     return { value: Promise.reject(42), done: false };
-  //   },
-  //   return() {
-  //     this.closed = true;
-  //     return { value: undefined, done: true };
-  //   },
-  // };
+  const closableIterator = {
+    closed: false,
+    [ITERATOR]() { return this; },
+    next() {
+      return { value: Promise.reject(42), done: false };
+    },
+    return() {
+      this.closed = true;
+      return { value: undefined, done: true };
+    },
+  };
 
   return Iterator.from([1, 2, 3]).toAsync().map(it => Promise.resolve(it)).toArray().then(it => {
     assert.arrayEqual(it, [1, 2, 3]);
     return Iterator.from(new Set([1, 2, 3])).toAsync().map(el => Promise.resolve(el)).toArray();
   }).then(it => {
     assert.arrayEqual(it, [1, 2, 3]);
-  });
-  /* Tests are temporarily disabled due to the lack of proper async feature detection.
-  .then(() => {
+  }).then(() => {
     return Iterator.from(closableIterator).toAsync().toArray();
   }).then(() => {
     assert.avoid();
   }, error => {
     assert.same(error, 42, 'rejection on a callback error');
     assert.true(closableIterator.closed, 'doesn\'t close sync iterator on promise rejection');
-  }); */
+  });
 });

--- a/tests/unit-pure/esnext.iterator.to-async.js
+++ b/tests/unit-pure/esnext.iterator.to-async.js
@@ -2,7 +2,7 @@ import { STRICT } from '../helpers/constants.js';
 
 import Promise from 'core-js-pure/es/promise';
 import Set from 'core-js-pure/es/set';
-import ITERATOR from 'core-js-pure/es/symbol/iterator';
+// import ITERATOR from 'core-js-pure/es/symbol/iterator';
 import Iterator from 'core-js-pure/actual/iterator';
 import 'core-js-pure/actual/async-iterator';
 
@@ -17,29 +17,31 @@ QUnit.test('Iterator#toAsync', assert => {
     assert.throws(() => toAsync.call(null), TypeError);
   }
 
-  const closableIterator = {
-    closed: false,
-    [ITERATOR]() { return this; },
-    next() {
-      return { value: Promise.reject(42), done: false };
-    },
-    return() {
-      this.closed = true;
-      return { value: undefined, done: true };
-    },
-  };
+  // const closableIterator = {
+  //   closed: false,
+  //   [ITERATOR]() { return this; },
+  //   next() {
+  //     return { value: Promise.reject(42), done: false };
+  //   },
+  //   return() {
+  //     this.closed = true;
+  //     return { value: undefined, done: true };
+  //   },
+  // };
 
   return Iterator.from([1, 2, 3]).toAsync().map(it => Promise.resolve(it)).toArray().then(it => {
     assert.arrayEqual(it, [1, 2, 3]);
     return Iterator.from(new Set([1, 2, 3])).toAsync().map(el => Promise.resolve(el)).toArray();
   }).then(it => {
     assert.arrayEqual(it, [1, 2, 3]);
-  }).then(() => {
+  });
+  /* Tests are temporarily disabled due to the lack of proper async feature detection.
+  .then(() => {
     return Iterator.from(closableIterator).toAsync().toArray();
   }).then(() => {
     assert.avoid();
   }, error => {
     assert.same(error, 42, 'rejection on a callback error');
     assert.true(closableIterator.closed, 'doesn\'t close sync iterator on promise rejection');
-  });
+  }); */
 });


### PR DESCRIPTION
Implementation of [tc39/ecma262#2600](https://github.com/tc39/ecma262/pull/2600)

Affected methods:
- `Array.prototype.fromAsync` (due to the lack of async feature detection capability  - temporarily, only in own core-js implementation)
- `AsyncIterator.prototype.from`
- `Iterator.prototype.toAsync`

