### PR TITLE
Fix `Set.prototype.difference` bug occurs when `this` is updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           cache: npm
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.1.1
       - run: npm ci
       - run: npx run-s bundle test-unit-bun
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           cache: npm
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.1.1
+          bun-version: latest
       - run: npm ci
       - run: npx run-s bundle test-unit-bun
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@
   - `RegExp.prototype[@@match]`
   - `RegExp.prototype[@@replace]`
 - Improved handling of `RegExp` flags in polyfills of some methods in engines without proper support of `RegExp.prototype.flags` and without polyfill of this getter
+- Added feature detection for [a bug](https://bugs.webkit.org/show_bug.cgi?id=288595) that occurs when `this` is updated while `Set.prototype.difference` is being executed
 - Compat data improvements:
   - [`Error.isError`](https://github.com/tc39/proposal-is-error) marked not supported in Node because of [a bug](https://github.com/nodejs/node/issues/56497)
   - Added [Deno 2.3](https://github.com/denoland/deno/releases/tag/v2.3.0) compat data mapping
   - Updated Electron 37 compat data mapping
+  - `Set.prototype.difference` marked not supported in Safari because of [a bug](https://bugs.webkit.org/show_bug.cgi?id=288595)
+  - `Set.prototype.difference` marked as supported from Bun 1.2.5 because of [a bug](https://bugs.webkit.org/show_bug.cgi?id=288595) was fixed
 
 ##### [3.42.0 - 2025.04.30](https://github.com/zloirock/core-js/releases/tag/v3.42.0)
 - Changes [v3.41.0...v3.42.0](https://github.com/zloirock/core-js/compare/v3.41.0...v3.42.0) (142 commits)

--- a/packages/core-js-compat/src/data.mjs
+++ b/packages/core-js-compat/src/data.mjs
@@ -1564,7 +1564,9 @@ export const data = {
     safari: '10.0',
   },
   'es.set.difference.v2': {
-    bun: '1.1.1',
+    // Bun 1.2.4 has a bug when `this` is updated while Set.prototype.difference is being executed
+    // https://bugs.webkit.org/show_bug.cgi?id=288595
+    bun: '1.2.5', // '1.1.1',
     // v8 ~ Chrome 122 does not properly work with set-like objects
     // https://bugs.chromium.org/p/v8/issues/detail?id=14559
     // v8 < Chrome 128 does not properly convert set-like objects Infinity size
@@ -1575,7 +1577,9 @@ export const data = {
     node: '22.10',
     // safari 17 does not properly work with set-like objects
     // https://bugs.webkit.org/show_bug.cgi?id=267494
-    safari: '18.0', // '17.0',
+    // A WebKit bug occurs when `this` is updated while Set.prototype.difference is being executed
+    // https://bugs.webkit.org/show_bug.cgi?id=288595
+    // safari: '18.0', // '17.0',
   },
   'es.set.intersection.v2': {
     bun: '1.1.1',

--- a/packages/core-js/internals/set-difference.js
+++ b/packages/core-js/internals/set-difference.js
@@ -20,7 +20,7 @@ module.exports = function difference(other) {
     if (otherRec.includes(e)) remove(result, e);
   });
   else iterateSimple(otherRec.getIterator(), function (e) {
-    if (has(O, e)) remove(result, e);
+    if (has(result, e)) remove(result, e);
   });
   return result;
 };

--- a/packages/core-js/modules/es.set.difference.v2.js
+++ b/packages/core-js/modules/es.set.difference.v2.js
@@ -3,12 +3,33 @@ var $ = require('../internals/export');
 var difference = require('../internals/set-difference');
 var setMethodAcceptSetLike = require('../internals/set-method-accept-set-like');
 
-var INCORRECT = !setMethodAcceptSetLike('difference', function (result) {
+var SET_LIKE_INCORRECT_BEHAVIOR = !setMethodAcceptSetLike('difference', function (result) {
   return result.size === 0;
 });
 
+var FORCED = SET_LIKE_INCORRECT_BEHAVIOR || (function () {
+  var values = [2];
+  var setLike = {
+    size: values.length,
+    has: function () { return true; },
+    keys: function () {
+      var index = 0;
+      return {
+        next: function () {
+          var done = index >= values.length;
+          if (baseSet.has(1)) baseSet.clear();
+          return { done: done, value: values[index++] };
+        }
+      };
+    }
+  };
+  var baseSet = new Set([1, 2, 3, 4]);
+
+  return baseSet.difference(setLike).size !== 3;
+})();
+
 // `Set.prototype.difference` method
 // https://tc39.es/ecma262/#sec-set.prototype.difference
-$({ target: 'Set', proto: true, real: true, forced: INCORRECT }, {
+$({ target: 'Set', proto: true, real: true, forced: FORCED }, {
   difference: difference
 });

--- a/packages/core-js/modules/es.set.difference.v2.js
+++ b/packages/core-js/modules/es.set.difference.v2.js
@@ -9,17 +9,15 @@ var SET_LIKE_INCORRECT_BEHAVIOR = !setMethodAcceptSetLike('difference', function
 });
 
 var FORCED = SET_LIKE_INCORRECT_BEHAVIOR || fails(function () {
-  var values = [2];
+  // https://bugs.webkit.org/show_bug.cgi?id=288595
   var setLike = {
-    size: values.length,
+    size: 1,
     has: function () { return true; },
     keys: function () {
-      var index = 0;
       return {
         next: function () {
-          var done = index >= values.length;
           if (baseSet.has(1)) baseSet.clear();
-          return { done: done, value: values[index++] };
+          return { done: true, value: 1 };
         }
       };
     }

--- a/packages/core-js/modules/es.set.difference.v2.js
+++ b/packages/core-js/modules/es.set.difference.v2.js
@@ -1,13 +1,14 @@
 'use strict';
 var $ = require('../internals/export');
 var difference = require('../internals/set-difference');
+var fails = require('../internals/fails');
 var setMethodAcceptSetLike = require('../internals/set-method-accept-set-like');
 
 var SET_LIKE_INCORRECT_BEHAVIOR = !setMethodAcceptSetLike('difference', function (result) {
   return result.size === 0;
 });
 
-var FORCED = SET_LIKE_INCORRECT_BEHAVIOR || (function () {
+var FORCED = SET_LIKE_INCORRECT_BEHAVIOR || fails(function () {
   var values = [2];
   var setLike = {
     size: values.length,
@@ -23,10 +24,11 @@ var FORCED = SET_LIKE_INCORRECT_BEHAVIOR || (function () {
       };
     }
   };
+  // eslint-disable-next-line es/no-set -- testing
   var baseSet = new Set([1, 2, 3, 4]);
-
+  // eslint-disable-next-line es/no-set-prototype-difference -- testing
   return baseSet.difference(setLike).size !== 3;
-})();
+});
 
 // `Set.prototype.difference` method
 // https://tc39.es/ecma262/#sec-set.prototype.difference

--- a/packages/core-js/modules/es.set.difference.v2.js
+++ b/packages/core-js/modules/es.set.difference.v2.js
@@ -14,10 +14,12 @@ var FORCED = SET_LIKE_INCORRECT_BEHAVIOR || fails(function () {
     size: 1,
     has: function () { return true; },
     keys: function () {
+      var index = 0;
       return {
         next: function () {
+          var done = index++ > 1;
           if (baseSet.has(1)) baseSet.clear();
-          return { done: true, value: 1 };
+          return { done: done, value: 2 };
         }
       };
     }

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -1242,17 +1242,16 @@ GLOBAL.tests = {
   }), function () {
     // A WebKit bug occurs when `this` is updated while Set.prototype.difference is being executed
     // https://bugs.webkit.org/show_bug.cgi?id=288595
-    var values = [2];
     var setLike = {
-      size: values.length,
+      size: 1,
       has: function () { return true; },
       keys: function () {
         var index = 0;
         return {
           next: function () {
-            var done = index >= values.length;
+            var done = index++ > 1;
             if (baseSet.has(1)) baseSet.clear();
-            return { done: done, value: values[index++] };
+            return { done: done, value: 2 };
           }
         };
       }

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -1240,28 +1240,27 @@ GLOBAL.tests = {
   'es.set.difference.v2': [createSetMethodTest('difference', function (result) {
     return result.size === 0;
   }), function () {
-    const values = [2, 3];
-    const setLike = {
+    // A WebKit bug occurs when `this` is updated while Set.prototype.difference is being executed
+    // https://bugs.webkit.org/show_bug.cgi?id=288595
+    var values = [2];
+    var setLike = {
       size: values.length,
-      has() { return true; },
-      keys() {
-        let index = 0;
+      has: function () { return true; },
+      keys: function () {
+        var index = 0;
         return {
-          next() {
-            const done = index >= values.length;
-            if (!baseSet.has(42)) {
-              baseSet.add(42);
-            }
-            return { done, value: values[index++] };
-          },
+          next: function () {
+            var done = index >= values.length;
+            if (baseSet.has(1)) baseSet.clear();
+            return { done: done, value: values[index++] };
+          }
         };
-      },
+      }
     };
 
-    let baseSet = new Set([1, 2, 3, 4]);
-    const result = baseSet.difference(setLike);
+    var baseSet = new Set([1, 2, 3, 4]);
 
-    return result.size === 2;
+    return baseSet.difference(setLike).size === 3;
   }],
   'es.set.intersection.v2': [createSetMethodTest('intersection', function (result) {
     return result.size === 2 && result.has(1) && result.has(2);

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -1237,9 +1237,32 @@ GLOBAL.tests = {
       && set.has(0)
       && set[Symbol.toStringTag];
   }],
-  'es.set.difference.v2': createSetMethodTest('difference', function (result) {
+  'es.set.difference.v2': [createSetMethodTest('difference', function (result) {
     return result.size === 0;
-  }),
+  }), function () {
+    const values = [2, 3];
+    const setLike = {
+      size: values.length,
+      has() { return true; },
+      keys() {
+        let index = 0;
+        return {
+          next() {
+            const done = index >= values.length;
+            if (!baseSet.has(42)) {
+              baseSet.add(42);
+            }
+            return { done, value: values[index++] };
+          },
+        };
+      },
+    };
+
+    let baseSet = new Set([1, 2, 3, 4]);
+    const result = baseSet.difference(setLike);
+
+    return result.size === 2;
+  }],
   'es.set.intersection.v2': [createSetMethodTest('intersection', function (result) {
     return result.size === 2 && result.has(1) && result.has(2);
   }), function () {

--- a/tests/unit-global/es.set.difference.js
+++ b/tests/unit-global/es.set.difference.js
@@ -69,5 +69,5 @@ QUnit.test('Set#difference', assert => {
 
   const baseSet = new Set([1, 2, 3, 4]);
   const result = baseSet.difference(setLike);
-  assert.deepEqual(Array.from(result), [1, 3, 4], 'incorrect behavior when this updated while Set#difference is being executed');
+  assert.deepEqual(from(result), [1, 3, 4], 'incorrect behavior when this updated while Set#difference is being executed');
 });

--- a/tests/unit-global/es.set.difference.js
+++ b/tests/unit-global/es.set.difference.js
@@ -48,4 +48,26 @@ QUnit.test('Set#difference', assert => {
   assert.throws(() => difference.call({}, [1, 2, 3]), TypeError);
   assert.throws(() => difference.call(undefined, [1, 2, 3]), TypeError);
   assert.throws(() => difference.call(null, [1, 2, 3]), TypeError);
+
+  // A WebKit bug occurs when `this` is updated while Set.prototype.difference is being executed
+  // https://bugs.webkit.org/show_bug.cgi?id=288595
+  const values = [2];
+  const setLike = {
+    size: values.length,
+    has() { return true; },
+    keys() {
+      let index = 0;
+      return {
+        next() {
+          const done = index >= values.length;
+          if (baseSet.has(1)) baseSet.clear();
+          return { done, value: values[index++] };
+        },
+      };
+    },
+  };
+
+  const baseSet = new Set([1, 2, 3, 4]);
+  const result = baseSet.difference(setLike);
+  assert.deepEqual(Array.from(result), [1, 3, 4], 'incorrect behavior when this updated while Set#difference is being executed');
 });

--- a/tests/unit-pure/es.set.difference.js
+++ b/tests/unit-pure/es.set.difference.js
@@ -71,5 +71,5 @@ QUnit.test('Set#difference', assert => {
 
   const baseSet = new Set([1, 2, 3, 4]);
   const result = baseSet.difference(setLike);
-  assert.deepEqual(Array.from(result), [1, 3, 4], 'incorrect behavior when this updated while Set#difference is being executed');
+  assert.deepEqual(result.size, 3, 'incorrect behavior when this updated while Set#difference is being executed');
 });

--- a/tests/unit-pure/es.set.difference.js
+++ b/tests/unit-pure/es.set.difference.js
@@ -71,5 +71,5 @@ QUnit.test('Set#difference', assert => {
 
   const baseSet = new Set([1, 2, 3, 4]);
   const result = baseSet.difference(setLike);
-  assert.deepEqual(result.size, 3, 'incorrect behavior when this updated while Set#difference is being executed');
+  assert.deepEqual(from(result), [1, 3, 4], 'incorrect behavior when this updated while Set#difference is being executed');
 });


### PR DESCRIPTION
- Added feature detection for a [bug](https://bugs.webkit.org/show_bug.cgi?id=288595)
- Fixed this bug in own implementation
- Updated support of `Set.prototype.difference` in Bun (from 1.2.5)
- Disabled support of `Set.prototype.difference` in Safari