### PR TITLE
Feature detection for WebKit bug in `TypedArray#with`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - `Iterator.prototype.flatMap`
   - `Iterator.prototype.map`
 - Added feature detection for Firefox bug: incorrect exception thrown by `Array.prototype.with` when index coercion fails
+- Added feature detection for WebKit bug: `TypedArray.prototype.with` should truncate negative fractional index to zero, but instead throws an error
 - Compat data improvements:
   - [`Error.isError`](https://github.com/tc39/proposal-is-error) marked not supported in Node because of [a bug](https://github.com/nodejs/node/issues/56497)
   - Added [Deno 2.3](https://github.com/denoland/deno/releases/tag/v2.3.0) compat data mapping
@@ -21,6 +22,7 @@
   - `Set.prototype.difference` marked as not supported in Safari and supported only from Bun 1.2.5 because of [a bug](https://bugs.webkit.org/show_bug.cgi?id=288595)
   - `Set.prototype.{ symmetricDifference, union }` marked as not supported in Safari and supported only from Bun 1.2.5 because of [a bug](https://bugs.webkit.org/show_bug.cgi?id=289430)
   - `Array.prototype.with` marked as unsupported in Firefox because it throws an incorrect exception when index coercion fails
+  - `TypedArray.prototype.with` marked as unsupported in Bun and Safari because it should truncate negative fractional index to zero, but instead throws an error
 
 ##### [3.42.0 - 2025.04.30](https://github.com/zloirock/core-js/releases/tag/v3.42.0)
 - Changes [v3.41.0...v3.42.0](https://github.com/zloirock/core-js/compare/v3.41.0...v3.42.0) (142 commits)

--- a/packages/core-js-compat/src/data.mjs
+++ b/packages/core-js-compat/src/data.mjs
@@ -2210,12 +2210,14 @@ export const data = {
     safari: '10.0',
   },
   'es.typed-array.with': {
-    bun: '0.1.9',
+    // It should truncate a negative fractional index to zero, but instead throws an error
+    // bun: '0.1.9',
     chrome: '110',
     deno: '1.27',
     firefox: '115',
     rhino: '1.8.0',
-    safari: '16.4',
+    // It should truncate a negative fractional index to zero, but instead throws an error
+    // safari: '16.4',
   },
   'es.unescape': {
     chrome: '1',

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -1661,13 +1661,21 @@ GLOBAL.tests = {
   'es.typed-array.to-sorted': function () {
     return Int8Array.prototype.toSorted;
   },
-  'es.typed-array.with': function () {
+  'es.typed-array.with': [function () {
     try {
       new Int8Array(1)['with'](2, { valueOf: function () { throw 8; } });
     } catch (error) {
       return error === 8;
     }
-  },
+  }, function () {
+    // WebKit doesn't handle this correctly. It should truncate a negative fractional index to zero, but instead throws an error
+    // Copyright (C) 2025 André Bargull. All rights reserved.
+    // This code is governed by the BSD license found in the LICENSE file.
+    // https://github.com/tc39/test262/pull/4477/commits/bd47071722d914036280cdd795a6ac6046d1c6f9
+    var ta = new Int8Array(1);
+    var result = ta['with'](-0.5, 1);
+    return result[0] === 1;
+  }],
   'es.unescape': function () {
     return unescape;
   },

--- a/tests/unit-global/es.typed-array.with.js
+++ b/tests/unit-global/es.typed-array.with.js
@@ -39,5 +39,8 @@ if (DESCRIPTORS) QUnit.test('%TypedArrayPrototype%.with', assert => {
         return error === 8;
       }
     }(), 'proper order of operations');
+
+    // WebKit doesn't handle this correctly. It should truncate a negative fractional index to zero, but instead throws an error
+    assert.same(new TypedArray(1).with(-0.5, $(1))[0], $(1));
   }
 });


### PR DESCRIPTION
- Added feature detection for WebKit bug: `TypedArray.prototype.with` should truncate negative fractional index to zero, but instead throws an error
- `TypedArray.prototype.with` marked as unsupported in Safari and Bun