### PR TITLE
`Iterator.from` bug in WebKit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added feature detection for Firefox bug: incorrect exception thrown by `Array.prototype.with` when index coercion fails
 - Added feature detection for WebKit bug: `TypedArray.prototype.with` should truncate negative fractional index to zero, but instead throws an error
 - Fixed deoptimization of the `Promise` polyfill in the pure version
+- Added feature detection for WebKit [bug](https://bugs.webkit.org/show_bug.cgi?id=288714): incorrect exception thrown by `Iterator.from` when underlying iterator's `return` method is null
 - Compat data improvements:
   - [`Error.isError`](https://github.com/tc39/proposal-is-error) marked not supported in Node because of [a bug](https://github.com/nodejs/node/issues/56497)
   - Added [Deno 2.3](https://github.com/denoland/deno/releases/tag/v2.3.0) compat data mapping
@@ -24,6 +25,7 @@
   - `Set.prototype.{ symmetricDifference, union }` marked as not supported in Safari and supported only from Bun 1.2.5 because of [a bug](https://bugs.webkit.org/show_bug.cgi?id=289430)
   - `Array.prototype.with` marked as unsupported in Firefox because it throws an incorrect exception when index coercion fails
   - `TypedArray.prototype.with` marked as unsupported in Bun and Safari because it should truncate negative fractional index to zero, but instead throws an error
+  - `Iterator.from` marked as not supported in Safari and supported only from Bun 1.2.5 because of [a bug](https://bugs.webkit.org/show_bug.cgi?id=288714)
 
 ##### [3.42.0 - 2025.04.30](https://github.com/zloirock/core-js/releases/tag/v3.42.0)
 - Changes [v3.41.0...v3.42.0](https://github.com/zloirock/core-js/compare/v3.41.0...v3.42.0) (142 commits)

--- a/packages/core-js-compat/src/data.mjs
+++ b/packages/core-js-compat/src/data.mjs
@@ -694,11 +694,13 @@ export const data = {
     // safari: '18.4',
   },
   'es.iterator.from': {
-    bun: '1.1.31',
+    // Because of a bug in wrapper validation https://bugs.webkit.org/show_bug.cgi?id=288714
+    bun: '1.2.5',  // '1.1.31',
     chrome: '122',
     deno: '1.38.1',
     firefox: '131',
-    safari: '18.4',
+    // Because of a bug in wrapper validation https://bugs.webkit.org/show_bug.cgi?id=288714
+    // safari: '18.4',
   },
   'es.iterator.map': {
     // with changes related to the new iteration closing approach on early error

--- a/packages/core-js/modules/es.iterator.from.js
+++ b/packages/core-js/modules/es.iterator.from.js
@@ -8,13 +8,24 @@ var createIteratorProxy = require('../internals/iterator-create-proxy');
 var getIteratorFlattenable = require('../internals/get-iterator-flattenable');
 var IS_PURE = require('../internals/is-pure');
 
+var FORCED = IS_PURE || function () {
+  // Should not throw when an underlying iterator's `return` method is null
+  // https://bugs.webkit.org/show_bug.cgi?id=288714
+  try {
+    // eslint-disable-next-line es/no-iterator -- required for testing
+    Iterator.from({ 'return': null })['return']();
+  } catch (error) {
+    return true;
+  }
+}();
+
 var IteratorProxy = createIteratorProxy(function () {
   return call(this.next, this.iterator);
 }, true);
 
 // `Iterator.from` method
 // https://tc39.es/ecma262/#sec-iterator.from
-$({ target: 'Iterator', stat: true, forced: IS_PURE }, {
+$({ target: 'Iterator', stat: true, forced: FORCED }, {
   from: function from(O) {
     var iteratorRecord = getIteratorFlattenable(typeof O == 'string' ? toObject(O) : O, true);
     return isPrototypeOf(IteratorPrototype, iteratorRecord.iterator)

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -791,7 +791,8 @@ GLOBAL.tests = {
   ],
   'es.iterator.for-each': checkIteratorClosingOnEarlyError('forEach', TypeError),
   'es.iterator.from': function () {
-    return Iterator.from;
+    Iterator.from({ 'return': null })['return']();
+    return true;
   },
   'es.iterator.map': [
     iteratorHelperThrowsErrorOnInvalidIterator('map', function () { /* empty */ }),

--- a/tests/unit-global/es.iterator.from.js
+++ b/tests/unit-global/es.iterator.from.js
@@ -21,4 +21,11 @@ QUnit.test('Iterator.from', assert => {
   assert.throws(() => from(null), TypeError);
   assert.throws(() => from({}).next(), TypeError);
   assert.throws(() => from(assign(new Iterator(), { next: 42 })).next(), TypeError);
+
+  // Should not throw when an underlying iterator's `return` method is null
+  // https://bugs.webkit.org/show_bug.cgi?id=288714
+  const iterator = createIterator([], { return: null });
+  const result = from(iterator).return('ignored');
+  assert.true(result.done, 'iterator with null next #1');
+  assert.strictEqual(result.value, undefined, 'iterator with null next #2');
 });

--- a/tests/unit-pure/es.iterator.from.js
+++ b/tests/unit-pure/es.iterator.from.js
@@ -19,4 +19,11 @@ QUnit.test('Iterator.from', assert => {
   assert.throws(() => from(null), TypeError);
   assert.throws(() => from({}).next(), TypeError);
   assert.throws(() => from(assign(new Iterator(), { next: 42 })).next(), TypeError);
+
+  // Should not throw when an underlying iterator's `return` method is null
+  // https://bugs.webkit.org/show_bug.cgi?id=288714
+  const iterator = createIterator([], { return: null });
+  const result = from(iterator).return('ignored');
+  assert.true(result.done, 'iterator with null next #1');
+  assert.strictEqual(result.value, undefined, 'iterator with null next #2');
 });


### PR DESCRIPTION
Added feature detection for [a bug](https://bugs.webkit.org/show_bug.cgi?id=288714) in WebKit: throw an error when underlying iterator's return method is null. Affected method `Iterator.from`