### PR TITLE
fix: update `Uint8Array.prototype.toHex` method to handle incorrect behavior in v8 staging

### DIFF
--- a/packages/core-js/modules/esnext.uint8-array.to-hex.js
+++ b/packages/core-js/modules/esnext.uint8-array.to-hex.js
@@ -7,9 +7,20 @@ var notDetached = require('../internals/array-buffer-not-detached');
 
 var numberToString = uncurryThis(1.1.toString);
 
+var Uint8Array = globalThis.Uint8Array;
+
+var INCORRECT_BEHAVIOR_OR_DOESNT_EXISTS = !Uint8Array || !Uint8Array.prototype.toHex || !(function () {
+  try {
+    var target = new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255]);
+    return target.toHex() === 'ffffffffffffffff';
+  } catch (error) {
+    return false;
+  }
+})();
+
 // `Uint8Array.prototype.toHex` method
 // https://github.com/tc39/proposal-arraybuffer-base64
-if (globalThis.Uint8Array) $({ target: 'Uint8Array', proto: true }, {
+if (Uint8Array) $({ target: 'Uint8Array', proto: true, forced: INCORRECT_BEHAVIOR_OR_DOESNT_EXISTS }, {
   toHex: function toHex() {
     anUint8Array(this);
     notDetached(this.buffer);

--- a/tests/unit-global/esnext.uint8-array.to-hex.js
+++ b/tests/unit-global/esnext.uint8-array.to-hex.js
@@ -7,7 +7,8 @@ if (DESCRIPTORS) QUnit.test('Uint8Array.prototype.toHex', assert => {
   assert.name(toHex, 'toHex');
   assert.looksNative(toHex);
 
-  assert.same(new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]).toHex(), '48656c6c6f20576f726c64', 'proper result');
+  assert.same(new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]).toHex(), '48656c6c6f20576f726c64', 'proper result #1');
+  assert.same(new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255]).toHex(), 'ffffffffffffffff', 'proper result #2');
 
   if (ArrayBuffer.prototype.transfer) {
     const array = new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]);


### PR DESCRIPTION
fixes #1439 