### PR TITLE
fix: add checks for incorrect behavior in `Uint8Array.fromBase64`, `setFromBase64`, and `toBase64` methods

### DIFF
--- a/packages/core-js/modules/esnext.uint8-array.from-base64.js
+++ b/packages/core-js/modules/esnext.uint8-array.from-base64.js
@@ -6,9 +6,17 @@ var $fromBase64 = require('../internals/uint8-from-base64');
 
 var Uint8Array = globalThis.Uint8Array;
 
+var INCORRECT_BEHAVIOR_OR_DOESNT_EXISTS = !Uint8Array || !Uint8Array.fromBase64 || !(function () {
+  try {
+    Uint8Array.fromBase64('', null);
+  } catch (error) {
+    return true;
+  }
+})();
+
 // `Uint8Array.fromBase64` method
 // https://github.com/tc39/proposal-arraybuffer-base64
-if (Uint8Array) $({ target: 'Uint8Array', stat: true }, {
+if (Uint8Array) $({ target: 'Uint8Array', stat: true, forced: INCORRECT_BEHAVIOR_OR_DOESNT_EXISTS }, {
   fromBase64: function fromBase64(string /* , options */) {
     var result = $fromBase64(string, arguments.length > 1 ? arguments[1] : undefined, null, 0x1FFFFFFFFFFFFF);
     return arrayFromConstructorAndList(Uint8Array, result.bytes);

--- a/packages/core-js/modules/esnext.uint8-array.set-from-base64.js
+++ b/packages/core-js/modules/esnext.uint8-array.set-from-base64.js
@@ -9,6 +9,12 @@ var Uint8Array = globalThis.Uint8Array;
 var INCORRECT_BEHAVIOR_OR_DOESNT_EXISTS = !Uint8Array || !Uint8Array.prototype.setFromBase64 || !(function () {
   var target = new Uint8Array([255, 255, 255, 255, 255]);
   try {
+    target.setFromBase64('', null);
+    return false;
+  } catch (error) {
+    // error is expected, so continue
+  }
+  try {
     target.setFromBase64('MjYyZg===');
   } catch (error) {
     return target[0] === 50 && target[1] === 54 && target[2] === 50 && target[3] === 255 && target[4] === 255;

--- a/packages/core-js/modules/esnext.uint8-array.to-base64.js
+++ b/packages/core-js/modules/esnext.uint8-array.to-base64.js
@@ -13,9 +13,20 @@ var base64UrlAlphabet = base64Map.i2cUrl;
 
 var charAt = uncurryThis(''.charAt);
 
+var Uint8Array = globalThis.Uint8Array;
+
+var INCORRECT_BEHAVIOR_OR_DOESNT_EXISTS = !Uint8Array || !Uint8Array.prototype.toBase64 || !(function () {
+  try {
+    var target = new Uint8Array();
+    target.toBase64(null);
+  } catch (error) {
+    return true;
+  }
+})();
+
 // `Uint8Array.prototype.toBase64` method
 // https://github.com/tc39/proposal-arraybuffer-base64
-if (globalThis.Uint8Array) $({ target: 'Uint8Array', proto: true }, {
+if (Uint8Array) $({ target: 'Uint8Array', proto: true, forced: INCORRECT_BEHAVIOR_OR_DOESNT_EXISTS }, {
   toBase64: function toBase64(/* options */) {
     var array = anUint8Array(this);
     var options = arguments.length ? anObjectOrUndefined(arguments[0]) : undefined;

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -2014,13 +2014,25 @@ GLOBAL.tests = {
     return Int8Array.prototype.uniqueBy;
   },
   'esnext.uint8-array.from-base64': function () {
-    return Uint8Array.fromBase64;
+    if (!Uint8Array.fromBase64) return false;
+    try {
+      Uint8Array.fromBase64('', null);
+    } catch (error) {
+      return true;
+    }
   },
   'esnext.uint8-array.from-hex': function () {
     return Uint8Array.fromHex;
   },
   'esnext.uint8-array.set-from-base64': function () {
+    if (!Uint8Array.prototype.setFromBase64) return false;
     var target = new Uint8Array([255, 255, 255, 255, 255]);
+    try {
+      target.setFromBase64('', null);
+      return false;
+    } catch (error) {
+      // error is expected, so continue
+    }
     try {
       target.setFromBase64('MjYyZg===');
     } catch (error) {
@@ -2031,10 +2043,22 @@ GLOBAL.tests = {
     return Uint8Array.prototype.setFromHex;
   },
   'esnext.uint8-array.to-base64': function () {
-    return Uint8Array.prototype.toBase64;
+    if (!Uint8Array.prototype.toBase64) return false;
+    try {
+      var target = new Uint8Array();
+      target.toBase64(null);
+    } catch (error) {
+      return true;
+    }
   },
   'esnext.uint8-array.to-hex': function () {
-    return Uint8Array.prototype.toHex;
+    if (!Uint8Array.prototype.toHex) return false;
+    try {
+      var target = new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255]);
+      return target.toHex() === 'ffffffffffffffff';
+    } catch (error) {
+      return false;
+    }
   },
   'esnext.weak-map.delete-all': function () {
     return WeakMap.prototype.deleteAll;


### PR DESCRIPTION
fixes #1439