### PR TITLE
Add Webkit bug detection for Uint8Array.setFromBase64/fromBase64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 ## Changelog
 ##### Unreleased
 - Added missing dependencies to some entries of static `Iterator` methods
+- Added detection of Webkit bug: `Uint8Array` fromBase64 / setFromBase64 does not throw an error on incorrect length of base64 string
 - Compat data improvements:
   - [`Uint8Array` to / from base64 and hex proposal](https://github.com/tc39/proposal-arraybuffer-base64) features marked as [supported from V8 ~ Chromium 140](https://issues.chromium.org/issues/42204568#comment37)
   - `%TypedArray%.prototype.with` marked as fixed in Safari 26.0
   - Updated Electron 38 compat data mapping
   - Added Opera Android 91 compat data mapping
+  - `Uint8Array` fromBase64 / setFromBase64 marked as unsupported in Safari and Bun because of a bug: it does not throw an error on incorrect length of base64 string
 
 ##### [3.44.0 - 2025.07.07](https://github.com/zloirock/core-js/releases/tag/v3.44.0)
 - Changes [v3.43.0...v3.44.0](https://github.com/zloirock/core-js/compare/v3.43.0...v3.44.0) (87 commits)

--- a/packages/core-js-compat/src/data.mjs
+++ b/packages/core-js-compat/src/data.mjs
@@ -2809,10 +2809,12 @@ export const data = {
   // TODO: Remove from `core-js@4`
   'esnext.typed-array.with': null,
   'esnext.uint8-array.from-base64': {
-    bun: '1.1.22',
+    // Because of a bug: it doesn't throw an error on incorrect length of base64 string
+    // bun: '1.1.22',
     chrome: '140',
     firefox: '133',
-    safari: '18.2',
+    // Because of a bug: it doesn't throw an error on incorrect length of base64 string
+    // safari: '18.2',
   },
   'esnext.uint8-array.from-hex': {
     bun: '1.1.22',
@@ -2821,10 +2823,12 @@ export const data = {
     safari: '18.2',
   },
   'esnext.uint8-array.set-from-base64': {
-    bun: '1.1.22',
+    // Because of a bug: it doesn't throw an error on incorrect length of base64 string
+    // bun: '1.1.22',
     chrome: '140',
     firefox: '133',
-    safari: '18.2',
+    // Because of a bug: it doesn't throw an error on incorrect length of base64 string
+    // safari: '18.2',
   },
   'esnext.uint8-array.set-from-hex': {
     bun: '1.1.22',

--- a/packages/core-js/modules/esnext.uint8-array.from-base64.js
+++ b/packages/core-js/modules/esnext.uint8-array.from-base64.js
@@ -7,6 +7,11 @@ var $fromBase64 = require('../internals/uint8-from-base64');
 var Uint8Array = globalThis.Uint8Array;
 
 var INCORRECT_BEHAVIOR_OR_DOESNT_EXISTS = !Uint8Array || !Uint8Array.fromBase64 || !function () {
+  // Webkit not throw an error on odd length string
+  try {
+    Uint8Array.fromBase64('a');
+    return;
+  } catch (error) { /* empty */ }
   try {
     Uint8Array.fromBase64('', null);
   } catch (error) {

--- a/packages/core-js/modules/esnext.uint8-array.set-from-base64.js
+++ b/packages/core-js/modules/esnext.uint8-array.set-from-base64.js
@@ -12,6 +12,11 @@ var INCORRECT_BEHAVIOR_OR_DOESNT_EXISTS = !Uint8Array || !Uint8Array.prototype.s
     target.setFromBase64('', null);
     return;
   } catch (error) { /* empty */ }
+  // Webkit not throw an error on odd length string
+  try {
+    target.setFromBase64('a');
+    return;
+  } catch (error) { /* empty */ }
   try {
     target.setFromBase64('MjYyZg===');
   } catch (error) {

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -2017,6 +2017,10 @@ GLOBAL.tests = {
     return Int8Array.prototype.uniqueBy;
   },
   'esnext.uint8-array.from-base64': function () {
+    try {
+      Uint8Array.fromBase64('a');
+      return;
+    } catch (error) { /* empty */ }
     if (!Uint8Array.fromBase64) return false;
     try {
       Uint8Array.fromBase64('', null);
@@ -2032,6 +2036,10 @@ GLOBAL.tests = {
     try {
       target.setFromBase64('', null);
       return false;
+    } catch (error) { /* empty */ }
+    try {
+      target.setFromBase64('a');
+      return;
     } catch (error) { /* empty */ }
     try {
       target.setFromBase64('MjYyZg===');

--- a/tests/unit-global/esnext.uint8-array.from-base64.js
+++ b/tests/unit-global/esnext.uint8-array.from-base64.js
@@ -150,4 +150,6 @@ if (DESCRIPTORS) QUnit.test('Uint8Array.fromBase64', assert => {
     assert.same(arr.buffer.byteLength, 1);
     assert.arrayEqual(arr, [102], `ascii whitespace: ${ name }`);
   });
+
+  assert.throws(() => Uint8Array.fromBase64('a'), SyntaxError, 'throws error on incorrect length of base64 string');
 });

--- a/tests/unit-global/esnext.uint8-array.set-from-base64.js
+++ b/tests/unit-global/esnext.uint8-array.set-from-base64.js
@@ -286,4 +286,7 @@ if (DESCRIPTORS) QUnit.test('Uint8Array.prototype.setFromBase64', assert => {
   target = new Uint8Array([255, 255, 255, 255, 255]);
   assert.throws(() => target.setFromBase64('MjYyZg==='), SyntaxError, 'extra characters after padding');
   assert.arrayEqual(target, [50, 54, 50, 255, 255], 'decoding from MjYyZg=== should not write the last chunk because it has extra padding');
+
+  target = new Uint8Array([255, 255, 255, 255, 255]);
+  assert.throws(() => target.setFromBase64('a'), SyntaxError, 'throws error on incorrect length of base64 string');
 });


### PR DESCRIPTION
Added detection of a bug when method not throws an error on incorrect length base64 string for following methods:
- `Uint8Array.fromBase64`
- `Uint8Array.prototype.setFromBase64`