### PR TITLE
[NFC] Remove unused postinstall for core-js-pure

### DIFF
--- a/packages/core-js-pure/package.json
+++ b/packages/core-js-pure/package.json
@@ -72,8 +72,5 @@
   "sideEffects": [
     "./modules/*.js"
   ],
-  "main": "index.js",
-  "scripts": {
-    "postinstall": "node -e \"try{require('./postinstall')}catch(e){}\""
-  }
+  "main": "index.js"
 }


### PR DESCRIPTION
There is no postinstall.js file in this directory, so the postinstall is always a no-op.

---

Reasoning: `pnpm` only allows whitelisted postinstall scripts to run by default, and emits a warning message. Due to the recent supply chain attack exploiting postinstall scripts, it's a good idea to only allow safe postinstall scripts, and the less noise from unused ones, the better.

Thus, I've removed the unused postinstall script for core-js-pure, as it doesn't do anything (it just try/catches the require of a non-existent file). I have not done the same for the other packages, as they're clearly using a postinstall.js script.

