### PR TITLE
Fix `Iterator.zip` and `Iterator.zipKeyed` behavior with `mode: 'longest'` option (#1469)

### DIFF
--- a/packages/core-js/internals/iterator-zip.js
+++ b/packages/core-js/internals/iterator-zip.js
@@ -28,7 +28,7 @@ var IteratorProxy = createIteratorProxy(function () {
   for (var i = 0; i < iterCount; i++) {
     var iter = iters[i];
     if (iter === null) {
-      push(results, padding[i]);
+      result = padding[i];
     } else {
       try {
         result = call(iter.next, iter.iterator);
@@ -79,8 +79,8 @@ var IteratorProxy = createIteratorProxy(function () {
         iters[i] = null;
         result = padding[i];
       }
-      push(results, result);
     }
+    push(results, result);
   }
 
   return finishResults ? finishResults(results) : results;

--- a/tests/unit-global/esnext.iterator.zip-keyed.js
+++ b/tests/unit-global/esnext.iterator.zip-keyed.js
@@ -62,15 +62,15 @@ QUnit.test('Iterator.zipKeyed', assert => {
   }
 
   {
-    const result = zipKeyed({
+    const $result = zipKeyed({
       a: [0, 1, 2],
       b: [3, 4, 5, 6, 7],
       c: [8, 9],
     }, {
-      mode: "longest",
+      mode: 'longest',
     });
 
-    assert.deepEqual(from(result), [
+    assert.deepEqual(from($result), [
       nullProto({ a: 0, b: 3, c: 8 }),
       nullProto({ a: 1, b: 4, c: 9 }),
       nullProto({ a: 2, b: 5, c: undefined }),
@@ -80,16 +80,16 @@ QUnit.test('Iterator.zipKeyed', assert => {
   }
 
   {
-    const result = zipKeyed({
+    const $result = zipKeyed({
       a: [0, 1, 2],
       b: [3, 4, 5, 6, 7],
       c: [8, 9],
     }, {
-      mode: "longest",
+      mode: 'longest',
       padding: { a: 'A', b: 'B', c: 'C' },
     });
 
-    assert.deepEqual(from(result), [
+    assert.deepEqual(from($result), [
       nullProto({ a: 0, b: 3, c: 8 }),
       nullProto({ a: 1, b: 4, c: 9 }),
       nullProto({ a: 2, b: 5, c: 'C' }),

--- a/tests/unit-global/esnext.iterator.zip.js
+++ b/tests/unit-global/esnext.iterator.zip.js
@@ -64,39 +64,39 @@ QUnit.test('Iterator.zip', assert => {
   }
 
   {
-    const result = zip([
+    const $result = zip([
       [0, 1, 2],
       [3, 4, 5, 6, 7],
       [8, 9],
     ], {
-      mode: "longest",
+      mode: 'longest',
     });
 
-    assert.deepEqual(from(result), [
+    assert.deepEqual(from($result), [
       [0, 3, 8],
       [1, 4, 9],
       [2, 5, undefined],
       [undefined, 6, undefined],
-      [undefined, 7, undefined]
+      [undefined, 7, undefined],
     ]);
   }
 
   {
-    const result = zip([
+    const $result = zip([
       [0, 1, 2],
       [3, 4, 5, 6, 7],
       [8, 9],
     ], {
-      mode: "longest",
-      padding: ["A", "B", "C"],
+      mode: 'longest',
+      padding: ['A', 'B', 'C'],
     });
 
-    assert.deepEqual(from(result), [
+    assert.deepEqual(from($result), [
       [0, 3, 8],
       [1, 4, 9],
       [2, 5, 'C'],
       ['A', 6, 'C'],
-      ['A', 7, 'C']
+      ['A', 7, 'C'],
     ]);
   }
 });

--- a/tests/unit-pure/esnext.iterator.zip-keyed.js
+++ b/tests/unit-pure/esnext.iterator.zip-keyed.js
@@ -3,11 +3,13 @@ import { DESCRIPTORS } from '../helpers/constants.js';
 
 import defineProperty from 'core-js-pure/actual/object/define-property';
 import from from 'core-js-pure/es/array/from';
-import Symbol from 'core-js-pure/full/symbol';
+import assign from 'core-js-pure/es/object/assign';
+import create from 'core-js-pure/es/object/create';
+import Symbol from 'core-js-pure/es/symbol';
 import zipKeyed from 'core-js-pure/full/iterator/zip-keyed';
 
 function nullProto(obj) {
-  return Object.assign(Object.create(null), obj);
+  return assign(create(null), obj);
 }
 
 QUnit.test('Iterator.zipKeyed', assert => {
@@ -61,15 +63,15 @@ QUnit.test('Iterator.zipKeyed', assert => {
   }
 
   {
-    const result = zipKeyed({
+    const $result = zipKeyed({
       a: [0, 1, 2],
       b: [3, 4, 5, 6, 7],
       c: [8, 9],
     }, {
-      mode: "longest",
+      mode: 'longest',
     });
 
-    assert.deepEqual(from(result), [
+    assert.deepEqual(from($result), [
       nullProto({ a: 0, b: 3, c: 8 }),
       nullProto({ a: 1, b: 4, c: 9 }),
       nullProto({ a: 2, b: 5, c: undefined }),
@@ -79,16 +81,16 @@ QUnit.test('Iterator.zipKeyed', assert => {
   }
 
   {
-    const result = zipKeyed({
+    const $result = zipKeyed({
       a: [0, 1, 2],
       b: [3, 4, 5, 6, 7],
       c: [8, 9],
     }, {
-      mode: "longest",
+      mode: 'longest',
       padding: { a: 'A', b: 'B', c: 'C' },
     });
 
-    assert.deepEqual(from(result), [
+    assert.deepEqual(from($result), [
       nullProto({ a: 0, b: 3, c: 8 }),
       nullProto({ a: 1, b: 4, c: 9 }),
       nullProto({ a: 2, b: 5, c: 'C' }),

--- a/tests/unit-pure/esnext.iterator.zip.js
+++ b/tests/unit-pure/esnext.iterator.zip.js
@@ -62,39 +62,39 @@ QUnit.test('Iterator.zip', assert => {
   }
 
   {
-    const result = zip([
+    const $result = zip([
       [0, 1, 2],
       [3, 4, 5, 6, 7],
       [8, 9],
     ], {
-      mode: "longest",
+      mode: 'longest',
     });
 
-    assert.deepEqual(from(result), [
+    assert.deepEqual(from($result), [
       [0, 3, 8],
       [1, 4, 9],
       [2, 5, undefined],
       [undefined, 6, undefined],
-      [undefined, 7, undefined]
+      [undefined, 7, undefined],
     ]);
   }
 
   {
-    const result = zip([
+    const $result = zip([
       [0, 1, 2],
       [3, 4, 5, 6, 7],
       [8, 9],
     ], {
-      mode: "longest",
-      padding: ["A", "B", "C"],
+      mode: 'longest',
+      padding: ['A', 'B', 'C'],
     });
 
-    assert.deepEqual(from(result), [
+    assert.deepEqual(from($result), [
       [0, 3, 8],
       [1, 4, 9],
       [2, 5, 'C'],
       ['A', 6, 'C'],
-      ['A', 7, 'C']
+      ['A', 7, 'C'],
     ]);
   }
 });


### PR DESCRIPTION
Fixes #1469