### PR TITLE
Remove global `Function#toString` monkey patch

### DIFF
--- a/packages/core-js/internals/function-provenance.js
+++ b/packages/core-js/internals/function-provenance.js
@@ -1,0 +1,43 @@
+'use strict';
+var inspectSource = require('./inspect-source');
+var store = require('./shared-store');
+var isCallable = require('./is-callable');
+
+if (!isCallable(store.getFunctionProvenance)) {
+  // https://tc39.es/ecma262/#prod-NativeFunction
+  var NATIVE_CODE_RE = /\)\s*\{\s*\[\s*native\s+code\s*\]\s*\}\s*$/;
+  // eslint-disable-next-line es/no-weak-set -- safe
+  var CORE_JS_REGISTRY = typeof WeakSet === 'function' ? new WeakSet() : null;
+  // eslint-disable-next-line es/no-symbol -- safe
+  var CORE_JS_BRAND = typeof Symbol === 'function' ? Symbol('CORE_JS_BRAND') : '__CORE_JS_BRAND__';
+
+  function getFunctionProvenance(fn) {
+    return isCoreJs(fn) ? 'core-js' : isNative(fn) ? 'native' : 'external';
+  }
+
+  function isNative(fn) {
+    return NATIVE_CODE_RE.test(inspectSource(fn));
+  }
+
+  function isCoreJs(fn) {
+    return CORE_JS_REGISTRY ? CORE_JS_REGISTRY.has(fn) : Boolean(fn[CORE_JS_BRAND]);
+  }
+
+  function registerCoreJsFunction(fn) {
+    if (isNative(fn)) return;
+
+    if (CORE_JS_REGISTRY) {
+      CORE_JS_REGISTRY.add(fn);
+    } else {
+      fn[CORE_JS_BRAND] = true;
+    }
+  }
+
+  store.getFunctionProvenance = getFunctionProvenance;
+  store.registerCoreJsFunction = registerCoreJsFunction;
+}
+
+module.exports = {
+  getFunctionProvenance: store.getFunctionProvenance,
+  registerCoreJsFunction: store.registerCoreJsFunction
+};

--- a/packages/core-js/internals/weak-map-basic-detection.js
+++ b/packages/core-js/internals/weak-map-basic-detection.js
@@ -1,7 +1,8 @@
 'use strict';
 var globalThis = require('../internals/global-this');
 var isCallable = require('../internals/is-callable');
+var getFunctionProvenance = require('./function-provenance').getFunctionProvenance;
 
 var WeakMap = globalThis.WeakMap;
 
-module.exports = isCallable(WeakMap) && /native code/.test(String(WeakMap));
+module.exports = isCallable(WeakMap) && getFunctionProvenance(WeakMap) !== 'external';

--- a/tests/helpers/qunit-helpers.js
+++ b/tests/helpers/qunit-helpers.js
@@ -89,12 +89,13 @@ assign(assert, {
       message,
     });
   },
-  looksNative(fn, message = 'The function looks like a native') {
-    const source = Function.prototype.toString.call(fn);
+  looksNative(fn, message = 'The function is recognized as being native or from core-js') {
+    const provenance = globalThis['__core-js_shared__'].getFunctionProvenance(fn);
+    const expected = ['core-js', 'native'];
     this.pushResult({
-      result: /native code/.test(source),
-      actual: source,
-      expected: 'The function should look like a native',
+      result: expected.includes(provenance),
+      actual: provenance,
+      expected: expected.join(' or '),
       message,
     });
   },


### PR DESCRIPTION
Fixes https://github.com/zloirock/core-js/issues/1468.

I'd already written most of this PR before that issue got closed — I've left a comment in the issue explaining why I don't think it should be closed.

An alternative (partial) solution would be selectively overwriting `toString` of only core-js functions, which would at least eliminate the need for the global monkey patch, even though it still wouldn't solve the problem of degraded debugging experience. Let me know if that would be a preferable solution.

---

Instead of testing for `/native code/` in the monkey-patched serialized source, we now use the new utilities under `function-kind.js` for internal checking of whether a function comes from core-js, the platform, or elsewhere. In order of preference, core-js functions are stored in a weakmap, added as a unique symbol property, or added as a string property, depending on availability of `WeakMap` and `Symbol`. The new check for true native functions should now be more reliable too, e.g. it won't return false positives for third-party functions like `() => "{ [native code] }"`, though it can still return false positives if third-party code overrides the `toString` method of its functions.

Registration of core-js functions and detection of true native functions is handled through `shared-store` to avoid conflict with multiple versions (even if one version is older and regardless of loading order).