### PR TITLE
Add bug detection to Iterator flatMap method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Use `CreateDataProperty` / `CreateDataPropertyOrThrow` in some missed cases, [#1497](https://github.com/zloirock/core-js/issues/1497)
 - Minor fix / optimization in the `RegExp` constructor (NCG and `dotAll`) polyfill
 - Added some more workarounds for a Safari < 13 bug with silent ignore of non-writable array `.length`
+- Added detection of a Webkit [bug](https://bugs.webkit.org/show_bug.cgi?id=297532): `Iterator.prototype.flatMap` throws on iterator without `return` method
 - Compat data improvements:
   - [`Map` upsert proposal](https://github.com/tc39/proposal-upsert) features marked as [shipped in V8 ~ Chrome 145](https://issues.chromium.org/issues/434977728#comment4)
   - [Joint iteration proposal](https://github.com/tc39/proposal-joint-iteration) features marked as [shipped in FF148](https://bugzilla.mozilla.org/show_bug.cgi?id=2003333#c8)
@@ -11,6 +12,7 @@
   - Added [Deno 2.6](https://github.com/denoland/deno/releases/tag/v2.6.0) compat data mapping
   - Added Opera Android [93](https://forums.opera.com/topic/87267/opera-for-android-93) and [94](https://forums.opera.com/topic/87678/opera-for-android-94) compat data mapping
   - Added Electron 41 compat data mapping
+  - `Iterator.prototype.flatMap` marked as supported from Safari 26.2 and Bun 1.2.21 because of a [bug](https://bugs.webkit.org/show_bug.cgi?id=297532): throws on iterator without `return` method
 
 ### [3.47.0 - 2025.11.18](https://github.com/zloirock/core-js/releases/tag/v3.47.0)
 - Changes [v3.46.0...v3.47.0](https://github.com/zloirock/core-js/compare/v3.46.0...v3.47.0) (117 commits)

--- a/packages/core-js-compat/src/data.mjs
+++ b/packages/core-js-compat/src/data.mjs
@@ -747,11 +747,13 @@ export const data = {
   'es.iterator.flat-map': {
     // with changes related to the new iteration closing approach on early error
     // https://github.com/tc39/ecma262/pull/3467
-    bun: '1.2.4', // '1.1.31',
+    // throws on iterator without `return` method
+    // https://bugs.webkit.org/show_bug.cgi?id=297532
+    bun: '1.2.21', // '1.2.4', '1.1.31'
     chrome: '135', // '122',
     deno: '2.2.5', // '1.38.1',
     firefox: '141', // '131',
-    safari: '26.0', // 18.4',
+    safari: '26.2', // '26.0', '18.4
   },
   'es.iterator.for-each': {
     // with changes related to the new iteration closing approach on early error

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -813,7 +813,17 @@ GLOBAL.tests = {
   'es.iterator.find': checkIteratorClosingOnEarlyError('find', TypeError),
   'es.iterator.flat-map': [
     iteratorHelperThrowsErrorOnInvalidIterator('flatMap', function () { /* empty */ }),
-    checkIteratorClosingOnEarlyError('flatMap', TypeError)
+    checkIteratorClosingOnEarlyError('flatMap', TypeError),
+    // Should not throw an error for an iterator without `return` method. Fixed in Safari 26.2
+    // https://bugs.webkit.org/show_bug.cgi?id=297532
+    function () {
+      try {
+        var it = new Map([[4, 5]]).entries().flatMap(function (v) { return v; });
+        it.next();
+        it['return']();
+        return true;
+      } catch (error) { /* empty */ }
+    }
   ],
   'es.iterator.for-each': checkIteratorClosingOnEarlyError('forEach', TypeError),
   'es.iterator.from': function () {

--- a/tests/unit-global/es.iterator.flat-map.js
+++ b/tests/unit-global/es.iterator.flat-map.js
@@ -23,6 +23,14 @@ QUnit.test('Iterator#flatMap', assert => {
     return [arg];
   }).toArray();
 
+  // Should not throw an error for an iterator without `return` method. Fixed in Safari 26.2
+  // https://bugs.webkit.org/show_bug.cgi?id=297532
+  assert.notThrows(() => {
+    const iter = flatMap.call(new Map([[4, 5]]).entries(), v => v);
+    iter.next();
+    iter.return();
+  }, 'iterator without `return` method');
+
   if (STRICT) {
     assert.throws(() => flatMap.call(undefined, () => { /* empty */ }), TypeError);
     assert.throws(() => flatMap.call(null, () => { /* empty */ }), TypeError);

--- a/tests/unit-pure/es.iterator.flat-map.js
+++ b/tests/unit-pure/es.iterator.flat-map.js
@@ -2,6 +2,7 @@ import { createIterator, createIterable } from '../helpers/helpers.js';
 import { STRICT, STRICT_THIS } from '../helpers/constants.js';
 
 import Iterator from 'core-js-pure/es/iterator';
+import Map from 'core-js-pure/es/map';
 
 QUnit.test('Iterator#flatMap', assert => {
   const { flatMap } = Iterator.prototype;
@@ -22,6 +23,14 @@ QUnit.test('Iterator#flatMap', assert => {
     assert.same(counter, 0, 'counter');
     return [arg];
   }).toArray();
+
+  // Should not throw an error for an iterator without `return` method. Fixed in Safari 26.2
+  // https://bugs.webkit.org/show_bug.cgi?id=297532
+  assert.notThrows(() => {
+    const iter = flatMap.call(new Map([[4, 5]]).entries(), v => v);
+    iter.next();
+    iter.return();
+  }, 'iterator without `return` method');
 
   if (STRICT) {
     assert.throws(() => flatMap.call(undefined, () => { /* empty */ }), TypeError);


### PR DESCRIPTION
Added [bug](https://bugs.webkit.org/show_bug.cgi?id=297532) detection for `Iterator.prototype.flatMap` that throws on iterator withour `return` method