### PR TITLE
Add bug detection for `Uint8Array.prototype.setFromHex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Minor fix / optimization in the `RegExp` constructor (NCG and `dotAll`) polyfill
 - Added some more workarounds for a Safari < 13 bug with silent ignore of non-writable array `.length`
 - Added detection of a Webkit [bug](https://bugs.webkit.org/show_bug.cgi?id=297532): `Iterator.prototype.flatMap` throws on iterator without `return` method
+- Added detection of a V8 ~ Chromium < 144 [bug](https://issues.chromium.org/issues/454630441): `Uint8Array.prototype.setFromHex` throws an error on length-tracking views over ResizableArrayBuffer
 - Compat data improvements:
   - [`Map` upsert proposal](https://github.com/tc39/proposal-upsert) features marked as [shipped in V8 ~ Chrome 145](https://issues.chromium.org/issues/434977728#comment4)
   - [Joint iteration proposal](https://github.com/tc39/proposal-joint-iteration) features marked as [shipped in FF148](https://bugzilla.mozilla.org/show_bug.cgi?id=2003333#c8)
@@ -21,6 +22,7 @@
   - Added Opera Android [93](https://forums.opera.com/topic/87267/opera-for-android-93) and [94](https://forums.opera.com/topic/87678/opera-for-android-94) compat data mapping
   - Added Electron 41 compat data mapping
   - `Iterator.prototype.flatMap` marked as supported from Safari 26.2 and Bun 1.2.21 because of a [bug](https://bugs.webkit.org/show_bug.cgi?id=297532): throws on iterator without `return` method
+  - `Uint8Array.prototype.setFromHex` marked as supported from V8 ~ Chromium 144 because of a [bug](https://issues.chromium.org/issues/454630441): throws an error on length-tracking views over ResizableArrayBuffer
 
 ### [3.47.0 - 2025.11.18](https://github.com/zloirock/core-js/releases/tag/v3.47.0)
 - Changes [v3.46.0...v3.47.0](https://github.com/zloirock/core-js/compare/v3.46.0...v3.47.0) (117 commits)

--- a/packages/core-js-compat/src/data.mjs
+++ b/packages/core-js-compat/src/data.mjs
@@ -2403,7 +2403,9 @@ export const data = {
   },
   'es.uint8-array.set-from-hex': {
     bun: '1.1.22',
-    chrome: '140',
+    // Should not throw an error on length-tracking views over ResizableArrayBuffer
+    // https://issues.chromium.org/issues/454630441
+    chrome: '144', // '140',
     firefox: '133',
     safari: '18.2',
   },

--- a/packages/core-js/modules/es.uint8-array.set-from-hex.js
+++ b/packages/core-js/modules/es.uint8-array.set-from-hex.js
@@ -6,9 +6,22 @@ var anUint8Array = require('../internals/an-uint8-array');
 var notDetached = require('../internals/array-buffer-not-detached');
 var $fromHex = require('../internals/uint8-from-hex');
 
+// Should not throw an error on length-tracking views over ResizableArrayBuffer
+// https://issues.chromium.org/issues/454630441
+function throwsOnLengthTrackingView() {
+  try {
+    // eslint-disable-next-line es/no-resizable-and-growable-arraybuffers -- required for testing
+    var rab = new ArrayBuffer(16, { maxByteLength: 1024 });
+    // eslint-disable-next-line es/no-uint8array-prototype-setfromhex, es/no-typed-arrays -- required for testing
+    new Uint8Array(rab).setFromHex('cafed00d');
+  } catch (error) {
+    return true;
+  }
+}
+
 // `Uint8Array.prototype.setFromHex` method
 // https://github.com/tc39/proposal-arraybuffer-base64
-if (globalThis.Uint8Array) $({ target: 'Uint8Array', proto: true }, {
+if (globalThis.Uint8Array) $({ target: 'Uint8Array', proto: true, forced: throwsOnLengthTrackingView() }, {
   setFromHex: function setFromHex(string) {
     anUint8Array(this);
     aString(string);

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -1787,7 +1787,13 @@ GLOBAL.tests = {
     }
   },
   'es.uint8-array.set-from-hex': function () {
-    return Uint8Array.prototype.setFromHex;
+    // Should not throw an error on length-tracking views over ResizableArrayBuffer
+    // https://issues.chromium.org/issues/454630441
+    try {
+      var rab = new ArrayBuffer(16, { maxByteLength: 1024 });
+      new Uint8Array(rab).setFromHex('cafed00d');
+      return true;
+    } catch (error) { /* empty */ }
   },
   'es.uint8-array.to-base64': function () {
     if (!Uint8Array.prototype.toBase64) return false;

--- a/tests/unit-global/es.uint8-array.set-from-hex.js
+++ b/tests/unit-global/es.uint8-array.set-from-hex.js
@@ -37,6 +37,13 @@ if (DESCRIPTORS) QUnit.test('Uint8Array.prototype.setFromHex', assert => {
     assert.throws(() => array5.setFromHex('48656c6c6f20576f726c64'), TypeError, 'detached');
   }
 
+  // Should not throw an error on length-tracking views over ResizableArrayBuffer
+  // https://issues.chromium.org/issues/454630441
+  assert.notThrows(() => {
+    const rab = new ArrayBuffer(16, { maxByteLength: 1024 });
+    new Uint8Array(rab).setFromHex('cafed00d');
+  }, 'not throw an error on ResizableArrayBuffer');
+
   assert.throws(() => setFromHex.call(Array(11), '48656c6c6f20576f726c64'), TypeError, "isn't generic, this #1");
   assert.throws(() => setFromHex.call(new Int8Array(11), '48656c6c6f20576f726c64'), TypeError, "isn't generic, this #2");
   assert.throws(() => new Uint8Array(11).setFromHex(null), TypeError, "isn't generic, arg #1");


### PR DESCRIPTION
Added [bug](https://issues.chromium.org/issues/454630441) detection for `Uint8Array.prototype.setFromHex` that throws an error on length-tracking views over ResizableArrayBuffer