### PR TITLE
Add a minify option to @core-js/builder v4.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,10 +49,24 @@
         "zx": "^8.8.5"
       }
     },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -76,6 +90,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -106,6 +121,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -115,6 +131,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.0.tgz",
       "integrity": "sha512-vSH118/wwM/pLR38g/Sgk05sNtro6TlTJKuiMXDaZqPUfjTFcudpCOt00IhOfj+1BFAX+UFAlzCU+6WXr3GLFQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -245,6 +262,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -268,6 +286,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -281,6 +300,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -352,6 +372,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -361,6 +382,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -379,6 +401,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
       "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -392,6 +415,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
       "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -928,6 +952,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -942,6 +967,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -960,6 +986,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -1003,6 +1030,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1412,6 +1440,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/core-js": {
@@ -1594,6 +1623,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1675,12 +1705,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -1709,6 +1741,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -1754,6 +1787,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/memorystream": {
@@ -2433,8 +2475,10 @@
       "version": "4.0.0-alpha.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
         "@core-js/compat": "4.0.0-alpha.0",
         "core-js": "4.0.0-alpha.0",
+        "magic-string": "^0.30.21",
         "webpack": "^5.104.1"
       },
       "engines": {

--- a/packages/core-js-builder/index.js
+++ b/packages/core-js-builder/index.js
@@ -2,11 +2,14 @@
 /* eslint-disable no-console -- output */
 const { promisify } = require('node:util');
 const { mkdir, readFile, unlink, writeFile } = require('node:fs/promises');
-const { dirname, join } = require('node:path');
+const { dirname, join, basename } = require('node:path');
 const tmpdir = require('node:os').tmpdir();
 const webpack = promisify(require('webpack'));
 const compat = require('@core-js/compat/compat');
 const { banner } = require('./config');
+const MagicString = require('magic-string');
+const remapping = require('@ampproject/remapping');
+const terser = require('terser');
 
 function normalizeSummary(unit = {}) {
   let size, modules;
@@ -18,6 +21,113 @@ function normalizeSummary(unit = {}) {
   } return { size, modules };
 }
 
+async function bundleModules(list, options) {
+  const { sourceMap, minify, filename, summary } = options;
+  const maps = {};
+  const files = {};
+
+  // --- Step 1: Webpack temp files ---
+  const webpackFileName = `core-js-webpack-${ Math.random().toString(36).slice(2) }.js`;
+  const webpackFile = join(tmpdir, webpackFileName);
+  const webpackMapFile = `${ webpackFile }.map`;
+
+  const tempFiles = [webpackFile, webpackMapFile]; // track files to delete later
+
+  try {
+    await webpack({
+      mode: 'none',
+      devtool: 'source-map',
+      node: false,
+      target: ['es5', 'node'],
+      entry: list.map(it => require.resolve(`core-js/modules/${ it }`)),
+      output: { filename: webpackFileName, path: tmpdir },
+    });
+
+    const webpackCode = String(await readFile(webpackFile));
+    files[webpackFileName] = webpackCode;
+
+    try {
+      maps[webpackFileName] = JSON.parse(await readFile(webpackMapFile, 'utf8'));
+    } catch {
+      maps[webpackFileName] = null;
+    }
+
+    // --- Step 2: Webpack require + IIFE edits + allow webpack require minify ---
+    const optimizeFileName = `core-js-optimize-${ Math.random().toString(36).slice(2) }.js`;
+    tempFiles.push(optimizeFileName);
+
+    const msOptimize = new MagicString(webpackCode);
+    msOptimize.replace(/function __webpack_require__/, 'var __webpack_require__ = function ');
+    msOptimize.prepend('!function (undefined) { \'use strict\'; ');
+    msOptimize.append(' \n}();\n');
+    const optimizeCode = msOptimize.toString();
+    files[optimizeFileName] = optimizeCode;
+    maps[optimizeFileName] = msOptimize.generateMap({ source: webpackFileName, hires: true, includeContent: true });
+
+    // --- Step 3: Minify (optional) ---
+    let minifyFileName = optimizeFileName;
+    if (minify) {
+      minifyFileName = `core-js-minify-${ Math.random().toString(36).slice(2) }.js`;
+      tempFiles.push(minifyFileName);
+
+      const terserResult = await terser.minify(optimizeCode, {
+        sourceMap: { content: maps[optimizeFileName], filename: optimizeFileName, url: false },
+        ecma: 3,
+        ie8: true,
+        safari10: true,
+        keep_fnames: true,
+        compress: {
+          hoist_funs: true,
+          hoist_vars: true,
+          passes: 2,
+          pure_getters: true,
+          typeofs: false,
+          unsafe_proto: true,
+          unsafe_undefined: true,
+        },
+        format: {
+          max_line_len: 32000,
+          webkit: true,
+          wrap_func_args: false,
+        },
+      });
+
+      files[minifyFileName] = terserResult.code;
+      maps[minifyFileName] = terserResult.map;
+    }
+
+    // --- Step 4: Header + Footer ---
+    const headerFooterFileName = `core-js-final-${ Math.random().toString(36).slice(2) }.js`;
+    tempFiles.push(headerFooterFileName);
+
+    const msFinal = new MagicString(files[minifyFileName]);
+    msFinal.prepend('\n');
+    msFinal.prepend(banner);
+    if (summary.comment.size) msFinal.append(`/*\n * size: ${ (files[minifyFileName].length / 1024).toFixed(2) }KB w/o comments\n */\n`);
+    if (summary.comment.modules) msFinal.append(`/*\n * modules:\n${ list.map(m => ` * ${ m }\n`).join('') } */\n`);
+    const finalCode = msFinal.toString();
+    files[headerFooterFileName] = finalCode;
+    maps[headerFooterFileName] = JSON.parse(
+      msFinal.generateMap({ source: minifyFileName, hires: true, includeContent: true }).toString(),
+    );
+
+    // --- Step 5: Compose maps ---
+    const composedMap = remapping(maps[headerFooterFileName], source => maps[source] || null);
+
+    // --- Step 6: Write final output ---
+    if (sourceMap && filename) {
+      await mkdir(dirname(filename), { recursive: true });
+      await writeFile(filename, `${ finalCode }\n//# sourceMappingURL=${ basename(filename) }.map`);
+      await writeFile(`${ filename }.map`, composedMap.toString());
+    }
+
+    return { code: finalCode, map: composedMap.toString() };
+  } finally {
+    // --- Step 7: Clean up temp files ---
+    await Promise.allSettled(tempFiles.map(f => unlink(f)));
+  }
+}
+
 module.exports = async function ({
   modules = null,
   exclude = [],
@@ -25,52 +135,30 @@ module.exports = async function ({
   format = 'bundle',
   filename = null,
   summary = {},
+  sourceMap = format === 'bundle',
+  minify = format === 'bundle',
 } = {}) {
   if (!['bundle', 'cjs', 'esm'].includes(format)) throw new TypeError('Incorrect output type');
   summary = { comment: normalizeSummary(summary.comment), console: normalizeSummary(summary.console) };
+  if ((minify || sourceMap) && format !== 'bundle') throw new TypeError('Cannot use minify or sourceMap with a non-bundle format');
 
   const TITLE = filename !== null || filename !== undefined ? filename : '`core-js`';
-  let script = banner;
-  let code = '\n';
-
   const { list, targets: compatTargets } = compat({ targets, modules, exclude });
 
+  let script = '';
+  let map = '';
   if (list.length) {
     if (format === 'bundle') {
-      const tempFileName = `core-js-${ Math.random().toString(36).slice(2) }.js`;
-      const tempFile = join(tmpdir, tempFileName);
-
-      await webpack({
-        mode: 'none',
-        node: false,
-        target: ['es5', 'node'],
-        entry: list.map(it => require.resolve(`core-js/modules/${ it }`)),
-        output: {
-          filename: tempFileName,
-          path: tmpdir,
-        },
-      });
-
-      const file = await readFile(tempFile);
-
-      await unlink(tempFile);
-
-      code = `!function (undefined) { 'use strict'; ${
-        // compress `__webpack_require__` with `keep_fnames` option
-        String(file).replace(/function __webpack_require__/, 'var __webpack_require__ = function ')
-      } }();\n`;
+      const result = await bundleModules(list, { sourceMap, minify, filename, summary });
+      script = result.code;
+      map = result.map;
     } else {
       const template = it => format === 'esm'
         ? `import 'core-js/modules/${ it }.js';\n`
         : `require('core-js/modules/${ it }');\n`;
-      code = list.map(template).join('');
+      script = list.map(template).join('');
     }
   }
-
-  if (summary.comment.size) script += `/*\n * size: ${ (code.length / 1024).toFixed(2) }KB w/o comments\n */`;
-  if (summary.comment.modules) script += `/*\n * modules:\n${ list.map(it => ` * ${ it }\n`).join('') } */`;
-  if (code) script += `\n${ code }`;
-
   if (summary.console.size) {
     console.log(`\u001B[32mbundling \u001B[36m${ TITLE }\u001B[32m, size: \u001B[36m${
       (script.length / 1024).toFixed(2)
@@ -87,7 +175,10 @@ module.exports = async function ({
   if (!(filename === null || filename === undefined)) {
     await mkdir(dirname(filename), { recursive: true });
     await writeFile(filename, script);
+    if (sourceMap) {
+      await writeFile(`${ filename }.map`, map);
+    }
   }
 
-  return { script };
+  return { script, map };
 };

--- a/packages/core-js-builder/package.json
+++ b/packages/core-js-builder/package.json
@@ -29,8 +29,10 @@
   "main": "index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "core-js": "4.0.0-alpha.0",
+    "@ampproject/remapping": "^2.3.0",
     "@core-js/compat": "4.0.0-alpha.0",
+    "core-js": "4.0.0-alpha.0",
+    "magic-string": "^0.30.21",
     "webpack": "^5.104.1"
   },
   "engines": {

--- a/scripts/bundle-package/bundle-package.mjs
+++ b/scripts/bundle-package/bundle-package.mjs
@@ -1,6 +1,4 @@
-import { minify } from 'terser';
 import builder from '@core-js/builder';
-import config from '@core-js/builder/config.js';
 
 const { cyan, green } = chalk;
 const ESMODULES = argv._.includes('esmodules');
@@ -14,40 +12,17 @@ function log(kind, name, code) {
 }
 
 async function bundle({ bundled, minified, options = {} }) {
-  const { script } = await builder({ modules: 'full', ...options });
+  const { script, map } = await builder({ modules: 'full', ...options });
 
-  log('bundling', bundled, script);
-  await fs.writeFile(`${ PATH }${ bundled }.js`, script);
-
-  const { code, map } = await minify(script, {
-    ecma: 5,
-    safari10: true,
-    keep_fnames: true,
-    compress: {
-      hoist_funs: true,
-      hoist_vars: true,
-      passes: 2,
-      pure_getters: true,
-      // document.all detection case
-      typeofs: false,
-      unsafe_proto: true,
-      unsafe_undefined: true,
-    },
-    format: {
-      max_line_len: 32000,
-      preamble: config.banner,
-      webkit: true,
-      // https://v8.dev/blog/preparser#pife
-      wrap_func_args: false,
-    },
-    sourceMap: {
-      url: `${ minified }.js.map`,
-    },
-  });
-
-  await fs.writeFile(`${ PATH }${ minified }.js`, code);
+  log('bundling minified', minified, script);
+  await fs.writeFile(`${ PATH }${ minified }.js`, script);
   await fs.writeFile(`${ PATH }${ minified }.js.map`, map);
-  log('minification', minified, code);
+
+  const { script: script2, map: map2 } = await builder({ modules: 'full', minify: false, ...options });
+
+  log('bundling regular', bundled, script2);
+  await fs.writeFile(`${ PATH }${ bundled }.js`, script2);
+  await fs.writeFile(`${ PATH }${ bundled }.js.map`, map2);
 }
 
 await bundle({

--- a/tests/builder/builder.mjs
+++ b/tests/builder/builder.mjs
@@ -17,4 +17,14 @@ ok(!script.includes("import 'core-js/modules/es.typed-array.with.js';"), 'actual
 ok(!script.includes("import 'core-js/modules/es.object.group-by.js';"), 'actual node 16 #7');
 ok(!script.includes("import 'core-js/modules/esnext.weak-set.from.js';"), 'actual node 16 #8');
 
+const { script: bundle } = await builder({
+  modules: 'actual',
+  exclude: [/group-by/, 'es.typed-array.with'],
+  targets: { node: 16 },
+  format: 'bundle',
+});
+
+ok(!bundle.includes("import 'core-js/modules/es.error.cause.js';"), 'bundled format contains import');
+ok(!bundle.includes('__webpack_require__'), 'bundled format did not minify internal function name');
+
 echo(chalk.green('builder tested'));


### PR DESCRIPTION
Adds a minify option to v4 of core-js's builder -- included in checklist at #1310.

This is my second attempt at doing so; this time, the source maps should all work properly and be resolved to the original location of the code in webpack.