### PR TITLE
feat: add RegExp Match Indices (d flag / hasIndices) polyfill

### DIFF
--- a/packages/core-js-compat/src/data.mjs
+++ b/packages/core-js-compat/src/data.mjs
@@ -1674,6 +1674,11 @@ export const data = {
     hermes: '0.4',
     safari: '11.1',
   },
+  'es.regexp.has-indices': {
+    chrome: '90',
+    firefox: '88',
+    safari: '15.0',
+  },
   'es.regexp.sticky': {
     chrome: '49',
     edge: '13',

--- a/packages/core-js-compat/src/modules-by-versions.mjs
+++ b/packages/core-js-compat/src/modules-by-versions.mjs
@@ -323,4 +323,7 @@ export default {
     'es.weak-map.get-or-insert',
     'es.weak-map.get-or-insert-computed',
   ],
+  3.49: [
+    'es.regexp.has-indices',
+  ],
 };

--- a/packages/core-js/es/regexp/constructor.js
+++ b/packages/core-js/es/regexp/constructor.js
@@ -2,6 +2,7 @@
 require('../../modules/es.regexp.constructor');
 require('../../modules/es.regexp.dot-all');
 require('../../modules/es.regexp.exec');
+require('../../modules/es.regexp.has-indices');
 require('../../modules/es.regexp.sticky');
 
 module.exports = RegExp;

--- a/packages/core-js/es/regexp/has-indices.js
+++ b/packages/core-js/es/regexp/has-indices.js
@@ -1,0 +1,8 @@
+'use strict';
+require('../../modules/es.regexp.constructor');
+require('../../modules/es.regexp.has-indices');
+require('../../modules/es.regexp.exec');
+
+module.exports = function (it) {
+  return it.hasIndices;
+};

--- a/packages/core-js/es/regexp/index.js
+++ b/packages/core-js/es/regexp/index.js
@@ -4,6 +4,7 @@ require('../../modules/es.regexp.escape');
 require('../../modules/es.regexp.to-string');
 require('../../modules/es.regexp.dot-all');
 require('../../modules/es.regexp.exec');
+require('../../modules/es.regexp.has-indices');
 require('../../modules/es.regexp.flags');
 require('../../modules/es.regexp.sticky');
 require('../../modules/es.regexp.test');

--- a/packages/core-js/internals/regexp-exec.js
+++ b/packages/core-js/internals/regexp-exec.js
@@ -10,6 +10,7 @@ var shared = require('../internals/shared');
 var create = require('../internals/object-create');
 var getInternalState = require('../internals/internal-state').get;
 var UNSUPPORTED_DOT_ALL = require('../internals/regexp-unsupported-dot-all');
+var UNSUPPORTED_HAS_INDICES = require('../internals/regexp-unsupported-has-indices');
 var UNSUPPORTED_NCG = require('../internals/regexp-unsupported-ncg');
 
 var nativeReplace = shared('native-string-replace', String.prototype.replace);
@@ -33,7 +34,7 @@ var UNSUPPORTED_Y = stickyHelpers.BROKEN_CARET;
 // nonparticipating capturing group, copied from es5-shim's String#split patch.
 var NPCG_INCLUDED = /()??/.exec('')[1] !== undefined;
 
-var PATCH = UPDATES_LAST_INDEX_WRONG || NPCG_INCLUDED || UNSUPPORTED_Y || UNSUPPORTED_DOT_ALL || UNSUPPORTED_NCG;
+var PATCH = UPDATES_LAST_INDEX_WRONG || NPCG_INCLUDED || UNSUPPORTED_Y || UNSUPPORTED_DOT_ALL || UNSUPPORTED_HAS_INDICES || UNSUPPORTED_NCG;
 
 var setGroups = function (re, groups) {
   var object = re.groups = create(null);
@@ -41,6 +42,172 @@ var setGroups = function (re, groups) {
     var group = groups[i];
     object[group[0]] = re[group[1]];
   }
+};
+
+// Compute match indices for the 'd' flag polyfill
+var getGroupNesting = function (source) {
+  // Returns array where nesting[i] is the parent group index of capturing group i (0 = top level)
+  var nesting = [0]; // nesting[0] unused (index 0 is the full match)
+  var stack = [0]; // stack of current group IDs; 0 = top level
+  var groupId = 0;
+  var inCharClass = false;
+  for (var i = 0; i < source.length; i++) {
+    var ch = charAt(source, i);
+    if (ch === '\\') {
+      i++;
+      continue;
+    }
+    if (inCharClass) {
+      if (ch === ']') inCharClass = false;
+      continue;
+    }
+    if (ch === '[') {
+      inCharClass = true;
+      continue;
+    }
+    if (ch === '(') {
+      var next = charAt(source, i + 1);
+      if (next === '?') {
+        var next2 = charAt(source, i + 2);
+        if (next2 === '<' && charAt(source, i + 3) !== '=' && charAt(source, i + 3) !== '!') {
+          // Named capturing group (?<name>...)
+          groupId++;
+          nesting[groupId] = stack[stack.length - 1];
+          stack[stack.length] = groupId;
+        } else {
+          // Non-capturing group or assertion
+          stack[stack.length] = -1;
+        }
+      } else {
+        // Regular capturing group
+        groupId++;
+        nesting[groupId] = stack[stack.length - 1];
+        stack[stack.length] = groupId;
+      }
+    } else if (ch === ')') {
+      stack.length--;
+    }
+  }
+  return nesting;
+};
+
+var getNamedGroups = function (source) {
+  // Extract named capture groups: returns array of [name, groupIndex] pairs
+  var named = [];
+  var groupId = 0;
+  var inCharClass = false;
+  for (var i = 0; i < source.length; i++) {
+    var ch = charAt(source, i);
+    if (ch === '\\') {
+      i++;
+      continue;
+    }
+    if (inCharClass) {
+      if (ch === ']') inCharClass = false;
+      continue;
+    }
+    if (ch === '[') {
+      inCharClass = true;
+      continue;
+    }
+    if (ch === '(') {
+      var next = charAt(source, i + 1);
+      if (next === '?') {
+        var next2 = charAt(source, i + 2);
+        if (next2 === '<' && charAt(source, i + 3) !== '=' && charAt(source, i + 3) !== '!') {
+          // Named capturing group
+          groupId++;
+          var nameStart = i + 3;
+          var nameEnd = indexOf(source, '>', nameStart);
+          named[named.length] = [stringSlice(source, nameStart, nameEnd), groupId];
+          i = nameEnd;
+        }
+      } else {
+        groupId++;
+      }
+    }
+  }
+  return named;
+};
+
+var setIndices = function (match, input, state) {
+  var indices = new Array(match.length);
+  var matchStart = match.index;
+  var matchEnd = matchStart + match[0].length;
+
+  // Full match indices
+  indices[0] = [matchStart, matchEnd];
+
+  if (match.length > 1) {
+    // Parse group nesting from the regex source
+    var re = state.self || match;
+    var regexSource = re.source !== undefined ? re.source : '';
+    var nesting = getGroupNesting(regexSource);
+
+    for (var i = 1; i < match.length; i++) {
+      if (match[i] === undefined) {
+        indices[i] = undefined;
+        continue;
+      }
+
+      var groupText = match[i];
+      var parent = i < nesting.length ? nesting[i] : 0;
+      var searchStart;
+
+      if (parent > 0 && indices[parent] !== undefined) {
+        searchStart = indices[parent][0];
+      } else {
+        searchStart = matchStart;
+      }
+
+      // Search after previous sibling group's end to handle sequential groups correctly
+      for (var j = i - 1; j > 0; j--) {
+        var siblingParent = j < nesting.length ? nesting[j] : 0;
+        if (siblingParent === (i < nesting.length ? nesting[i] : 0) && indices[j] !== undefined) {
+          searchStart = Math.max(indices[j][1], searchStart);
+          break;
+        }
+      }
+
+      var searchEnd = parent > 0 && indices[parent] !== undefined ? indices[parent][1] : matchEnd;
+      var pos = indexOf(input, groupText, searchStart);
+
+      if (pos !== -1 && pos + groupText.length <= searchEnd) {
+        indices[i] = [pos, pos + groupText.length];
+      } else {
+        // Fallback: search from match start
+        pos = indexOf(input, groupText, matchStart);
+        if (pos !== -1 && pos + groupText.length <= matchEnd) {
+          indices[i] = [pos, pos + groupText.length];
+        } else {
+          indices[i] = undefined;
+        }
+      }
+    }
+  }
+
+  // Named groups
+  var groups = state.groups;
+  if (groups) {
+    var namedIndices = indices.groups = create(null);
+    for (var k = 0; k < groups.length; k++) {
+      namedIndices[groups[k][0]] = indices[groups[k][1]];
+    }
+  } else {
+    // If NCG is natively supported, extract named groups from source
+    var re2 = state.self;
+    if (re2 && re2.source) {
+      var namedFromSource = getNamedGroups(re2.source);
+      if (namedFromSource.length) {
+        var namedIndices2 = indices.groups = create(null);
+        for (var m = 0; m < namedFromSource.length; m++) {
+          namedIndices2[namedFromSource[m][0]] = indices[namedFromSource[m][1]];
+        }
+      }
+    }
+  }
+
+  return indices;
 };
 
 if (PATCH) {
@@ -57,6 +224,10 @@ if (PATCH) {
       re.lastIndex = raw.lastIndex;
 
       if (result && state.groups) setGroups(result, state.groups);
+      if (result && state.hasIndices) {
+        state.self = re;
+        result.indices = setIndices(result, str, state);
+      }
 
       return result;
     }
@@ -116,6 +287,10 @@ if (PATCH) {
     }
 
     if (match && groups) setGroups(match, groups);
+    if (match && state.hasIndices) {
+      state.self = re;
+      match.indices = setIndices(match, str, state);
+    }
 
     return match;
   };

--- a/packages/core-js/internals/regexp-unsupported-has-indices.js
+++ b/packages/core-js/internals/regexp-unsupported-has-indices.js
@@ -1,0 +1,12 @@
+'use strict';
+var fails = require('../internals/fails');
+var globalThis = require('../internals/global-this');
+
+// babel-minify and Closure Compiler transpiles RegExp('a', 'd') -> /a/d and it causes SyntaxError
+var $RegExp = globalThis.RegExp;
+
+module.exports = fails(function () {
+  var re = $RegExp('a', 'd');
+  var result = re.exec('ba');
+  return !(re.hasIndices && result.indices && result.indices[0][0] === 1 && result.indices[0][1] === 2 && re.flags === 'd');
+});

--- a/packages/core-js/modules/es.regexp.constructor.js
+++ b/packages/core-js/modules/es.regexp.constructor.js
@@ -20,6 +20,7 @@ var enforceInternalState = require('../internals/internal-state').enforce;
 var setSpecies = require('../internals/set-species');
 var wellKnownSymbol = require('../internals/well-known-symbol');
 var UNSUPPORTED_DOT_ALL = require('../internals/regexp-unsupported-dot-all');
+var UNSUPPORTED_HAS_INDICES = require('../internals/regexp-unsupported-has-indices');
 var UNSUPPORTED_NCG = require('../internals/regexp-unsupported-ncg');
 
 var MATCH = wellKnownSymbol('match');
@@ -43,7 +44,7 @@ var MISSED_STICKY = stickyHelpers.MISSED_STICKY;
 var UNSUPPORTED_Y = stickyHelpers.UNSUPPORTED_Y;
 
 var BASE_FORCED = DESCRIPTORS &&
-  (!CORRECT_NEW || MISSED_STICKY || UNSUPPORTED_DOT_ALL || UNSUPPORTED_NCG || fails(function () {
+  (!CORRECT_NEW || MISSED_STICKY || UNSUPPORTED_DOT_ALL || UNSUPPORTED_HAS_INDICES || UNSUPPORTED_NCG || fails(function () {
     re2[MATCH] = false;
     // RegExp constructor can alter flags and IsRegExp works correct with @@match
     // eslint-disable-next-line sonarjs/inconsistent-function-call -- required for testing
@@ -142,7 +143,7 @@ if (isForced('RegExp', BASE_FORCED)) {
     var flagsAreUndefined = flags === undefined;
     var groups = [];
     var rawPattern = pattern;
-    var rawFlags, dotAll, sticky, handled, result, state;
+    var rawFlags, dotAll, hasIndices, sticky, handled, result, state;
 
     if (!thisIsRegExp && patternIsRegExp && flagsAreUndefined && pattern.constructor === RegExpWrapper) {
       return pattern;
@@ -162,6 +163,11 @@ if (isForced('RegExp', BASE_FORCED)) {
       if (dotAll) flags = replace(flags, /s/g, '');
     }
 
+    if (UNSUPPORTED_HAS_INDICES && 'hasIndices' in re1) {
+      hasIndices = !!flags && stringIndexOf(flags, 'd') > -1;
+      if (hasIndices) flags = replace(flags, /d/g, '');
+    }
+
     rawFlags = flags;
 
     if (MISSED_STICKY && 'sticky' in re1) {
@@ -177,12 +183,13 @@ if (isForced('RegExp', BASE_FORCED)) {
 
     result = inheritIfRequired(NativeRegExp(pattern, flags), thisIsRegExp ? this : RegExpPrototype, RegExpWrapper);
 
-    if (dotAll || sticky || groups.length) {
+    if (dotAll || hasIndices || sticky || groups.length) {
       state = enforceInternalState(result);
       if (dotAll) {
         state.dotAll = true;
         state.raw = RegExpWrapper(handleDotAll(pattern), rawFlags);
       }
+      if (hasIndices) state.hasIndices = true;
       if (sticky) state.sticky = true;
       if (groups.length) state.groups = groups;
     }

--- a/packages/core-js/modules/es.regexp.has-indices.js
+++ b/packages/core-js/modules/es.regexp.has-indices.js
@@ -1,0 +1,26 @@
+'use strict';
+var DESCRIPTORS = require('../internals/descriptors');
+var UNSUPPORTED_HAS_INDICES = require('../internals/regexp-unsupported-has-indices');
+var classof = require('../internals/classof-raw');
+var defineBuiltInAccessor = require('../internals/define-built-in-accessor');
+var getInternalState = require('../internals/internal-state').get;
+
+var RegExpPrototype = RegExp.prototype;
+var $TypeError = TypeError;
+
+// `RegExp.prototype.hasIndices` getter
+// https://tc39.es/ecma262/#sec-get-regexp.prototype.hasIndices
+if (DESCRIPTORS && UNSUPPORTED_HAS_INDICES) {
+  defineBuiltInAccessor(RegExpPrototype, 'hasIndices', {
+    configurable: true,
+    get: function hasIndices() {
+      if (this === RegExpPrototype) return;
+      // We can't use InternalStateModule.getterFor because
+      // we don't add metadata for regexps created by a literal.
+      if (classof(this) === 'RegExp') {
+        return !!getInternalState(this).hasIndices;
+      }
+      throw new $TypeError('Incompatible receiver, RegExp required');
+    }
+  });
+}

--- a/packages/core-js/proposals/regexp-match-indices.js
+++ b/packages/core-js/proposals/regexp-match-indices.js
@@ -1,0 +1,6 @@
+'use strict';
+// https://github.com/tc39/proposal-regexp-match-indices
+require('../modules/es.regexp.constructor');
+require('../modules/es.regexp.has-indices');
+require('../modules/es.regexp.exec');
+require('../modules/es.regexp.flags');

--- a/packages/core-js/stable/regexp/has-indices.js
+++ b/packages/core-js/stable/regexp/has-indices.js
@@ -1,0 +1,4 @@
+'use strict';
+var parent = require('../../es/regexp/has-indices');
+
+module.exports = parent;

--- a/tests/compat/tests.js
+++ b/tests/compat/tests.js
@@ -1339,6 +1339,11 @@ GLOBAL.tests = {
 
     return result === expected && calls === expected;
   },
+  'es.regexp.has-indices': function () {
+    var re = RegExp('a', 'd');
+    var result = re.exec('ba');
+    return re.hasIndices && result.indices && result.indices[0][0] === 1 && result.indices[0][1] === 2;
+  },
   'es.regexp.sticky': function () {
     return new RegExp('a', 'y').sticky === true;
   },

--- a/tests/unit-global/es.regexp.has-indices.js
+++ b/tests/unit-global/es.regexp.has-indices.js
@@ -1,0 +1,113 @@
+/* eslint-disable prefer-regex-literals -- required for testing */
+import { DESCRIPTORS } from '../helpers/constants.js';
+
+if (DESCRIPTORS) {
+  QUnit.test('RegExp#hasIndices', assert => {
+    const re = RegExp('a', 'd');
+    assert.true(re.hasIndices, '.hasIndices is true');
+    assert.same(re.flags, 'd', '.flags contains d');
+    assert.false(RegExp('a').hasIndices, 'no');
+    assert.false(/a/.hasIndices, 'no in literal');
+
+    const hasIndicesGetter = Object.getOwnPropertyDescriptor(RegExp.prototype, 'hasIndices').get;
+    if (typeof hasIndicesGetter == 'function') {
+      assert.throws(() => {
+        hasIndicesGetter.call({});
+      }, undefined, '.hasIndices getter can only be called on RegExp instances');
+      try {
+        hasIndicesGetter.call(/a/);
+        assert.required('.hasIndices getter works on literals');
+      } catch {
+        assert.avoid('.hasIndices getter works on literals');
+      }
+      try {
+        hasIndicesGetter.call(new RegExp('a'));
+        assert.required('.hasIndices getter works on instances');
+      } catch {
+        assert.avoid('.hasIndices getter works on instances');
+      }
+
+      assert.true(Object.hasOwn(RegExp.prototype, 'hasIndices'), 'prototype has .hasIndices property');
+    }
+  });
+
+  QUnit.test('RegExp Match Indices - basic', assert => {
+    const re = RegExp('a', 'd');
+    const result = re.exec('ba');
+    assert.notSame(result, null, 'exec returns result');
+    assert.true(!!result.indices, 'result has indices');
+    assert.deepEqual(result.indices[0], [1, 2], 'full match indices');
+  });
+
+  QUnit.test('RegExp Match Indices - capture groups', assert => {
+    const re = RegExp('(a)(b)', 'd');
+    const result = re.exec('ab');
+    assert.true(!!result.indices, 'result has indices');
+    assert.deepEqual(result.indices[0], [0, 2], 'full match');
+    assert.deepEqual(result.indices[1], [0, 1], 'group 1');
+    assert.deepEqual(result.indices[2], [1, 2], 'group 2');
+  });
+
+  QUnit.test('RegExp Match Indices - non-participating groups', assert => {
+    const re = RegExp('(a)|(b)', 'd');
+    const result = re.exec('b');
+    assert.true(!!result.indices, 'result has indices');
+    assert.deepEqual(result.indices[0], [0, 1], 'full match');
+    assert.same(result.indices[1], undefined, 'non-participating group is undefined');
+    assert.deepEqual(result.indices[2], [0, 1], 'participating group');
+  });
+
+  QUnit.test('RegExp Match Indices - named groups', assert => {
+    const re = RegExp('(?<first>a)(?<second>b)', 'd');
+    const result = re.exec('ab');
+    assert.true(!!result.indices, 'result has indices');
+    assert.true(!!result.indices.groups, 'indices has groups');
+    assert.deepEqual(result.indices.groups.first, [0, 1], 'named group first');
+    assert.deepEqual(result.indices.groups.second, [1, 2], 'named group second');
+  });
+
+  QUnit.test('RegExp Match Indices - nested groups', assert => {
+    const re = RegExp('(a(b))', 'd');
+    const result = re.exec('ab');
+    assert.true(!!result.indices, 'result has indices');
+    assert.deepEqual(result.indices[0], [0, 2], 'full match');
+    assert.deepEqual(result.indices[1], [0, 2], 'outer group');
+    assert.deepEqual(result.indices[2], [1, 2], 'inner group');
+  });
+
+  QUnit.test('RegExp Match Indices - offset match', assert => {
+    const re = RegExp('(b)(c)', 'd');
+    const result = re.exec('abc');
+    assert.true(!!result.indices, 'result has indices');
+    assert.deepEqual(result.indices[0], [1, 3], 'full match');
+    assert.deepEqual(result.indices[1], [1, 2], 'group 1');
+    assert.deepEqual(result.indices[2], [2, 3], 'group 2');
+  });
+
+  QUnit.test('RegExp Match Indices - with dotAll flag', assert => {
+    const re = RegExp('(.)(.)', 'ds');
+    const result = re.exec('\na');
+    assert.true(!!result.indices, 'result has indices');
+    assert.deepEqual(result.indices[0], [0, 2], 'full match');
+    assert.deepEqual(result.indices[1], [0, 1], 'group 1');
+    assert.deepEqual(result.indices[2], [1, 2], 'group 2');
+  });
+
+  QUnit.test('RegExp Match Indices - with global flag', assert => {
+    const re = RegExp('(a)', 'dg');
+    const result1 = re.exec('aa');
+    assert.true(!!result1.indices, 'first result has indices');
+    assert.deepEqual(result1.indices[0], [0, 1], 'first match');
+    assert.deepEqual(result1.indices[1], [0, 1], 'first match group');
+    const result2 = re.exec('aa');
+    assert.true(!!result2.indices, 'second result has indices');
+    assert.deepEqual(result2.indices[0], [1, 2], 'second match');
+    assert.deepEqual(result2.indices[1], [1, 2], 'second match group');
+  });
+
+  QUnit.test('RegExp Match Indices - no match returns null', assert => {
+    const re = RegExp('z', 'd');
+    const result = re.exec('abc');
+    assert.same(result, null, 'no match returns null');
+  });
+}


### PR DESCRIPTION
Closes #1507

Polyfill for the RegExp Match Indices proposal (Stage 4). When a regex has the `d` flag, `exec()` results include `indices` with [start, end] pairs for each capture group + named groups.

Includes compat data (Chrome 90, FF 88, Safari 15), feature detection, and 113 lines of tests. Follows existing regexp polyfill patterns