### PR TITLE
Crash fix in WSH runtime

### DIFF
--- a/packages/core-js/internals/object-create.js
+++ b/packages/core-js/internals/object-create.js
@@ -22,12 +22,36 @@ var scriptTag = function (content) {
 
 // Create object with fake `null` prototype: use ActiveX Object with cleared prototype
 var NullProtoObjectViaActiveX = function (activeXDocument) {
-  activeXDocument.write(scriptTag(''));
-  activeXDocument.close();
-  var temp = activeXDocument.parentWindow.Object;
+  var temp;
+  try {
+    activeXDocument.write(scriptTag(''));
+    activeXDocument.close();
+    temp = activeXDocument.parentWindow.Object;
+  } catch (error) {
+    temp = NullProtoObjectViaSc32bit();
+  }
   // eslint-disable-next-line no-useless-assignment -- avoid memory leak
   activeXDocument = null;
   return temp;
+};
+
+// Attempt to create a null-prototype-capable Object constructor
+// using the 32-bit-only MSScriptControl (ActiveX).
+// This will fail on 64-bit runtimes or when ScriptControl is unavailable.
+var sc32bit;
+
+var NullProtoObjectViaSc32bit = function() {
+  try {
+    sc32bit = new ActiveXObject("MSScriptControl.ScriptControl");
+    sc32bit.Language = "JScript";
+
+    // Return the Object constructor from the ScriptControl context
+    // (used to emulate Object.create(null)-like behavior)
+    return sc32bit.Eval("Object");
+  } catch (error) {
+    // Throw a clear error when running outside a supported (32-bit) environment
+    throw Error("This system supports null-prototype object creation only in 32-bit runtimes.");
+  }
 };
 
 // Create object with fake `null` prototype: use iframe Object with cleared prototype
@@ -61,7 +85,7 @@ var NullProtoObject = function () {
     ? document.domain && activeXDocument
       ? NullProtoObjectViaActiveX(activeXDocument) // old IE
       : NullProtoObjectViaIFrame()
-    : function () { return {}; }; // WSH or standalone ES3 runtime
+    : NullProtoObjectViaActiveX(activeXDocument); // WSH
   var length = enumBugKeys.length;
   while (length--) delete NullProtoObject[PROTOTYPE][enumBugKeys[length]];
   return NullProtoObject();

--- a/packages/core-js/internals/object-create.js
+++ b/packages/core-js/internals/object-create.js
@@ -62,12 +62,7 @@ var NullProtoObjectViaSc64bit = function () {
     sc64bit.Language = 'JScript';
     return sc64bit.Eval('Object');
   } catch (error) {
-    // If all attempts to retrieve a new object from an external instance fail,
-    // the existing object is returned.
-    // This prevents errors during the key deletion process using enumBugKeys afterward.
-    return function () {
-      return {};
-    };
+    throw new Error('Cannot create an object with a null prototype in the current environment.');
   }
 };
 

--- a/packages/core-js/internals/object-create.js
+++ b/packages/core-js/internals/object-create.js
@@ -65,9 +65,9 @@ var NullProtoObjectViaSc64bit = function () {
     // If all attempts to retrieve a new object from an external instance fail,
     // the existing object is returned.
     // This prevents errors during the key deletion process using enumBugKeys afterward.
-    return function() {
-        return {};
-    }
+    return function () {
+      return {};
+    };
   }
 }
 

--- a/packages/core-js/internals/object-create.js
+++ b/packages/core-js/internals/object-create.js
@@ -35,22 +35,35 @@ var NullProtoObjectViaActiveX = function (activeXDocument) {
   return temp;
 };
 
-// Attempt to create a null-prototype-capable Object constructor
-// using the 32-bit-only MSScriptControl (ActiveX).
-// This will fail on 64-bit runtimes or when ScriptControl is unavailable.
+// Attempt to obtain an Object constructor capable of creating
+// null-prototype objects using 32-bit MSScriptControl.
+// This approach only works in 32-bit environments where ScriptControl is available.
 var sc32bit;
 
+// Function to retrieve Object constructor via 32-bit ScriptControl (typically provided by Microsoft)
 var NullProtoObjectViaSc32bit = function () {
   try {
     sc32bit = new ActiveXObject('MSScriptControl.ScriptControl');
     sc32bit.Language = 'JScript';
-
-    // Return the Object constructor from the ScriptControl context
-    // (used to emulate Object.create(null)-like behavior)
     return sc32bit.Eval('Object');
   } catch (error) {
-    // Throw a clear error when running outside a supported (32-bit) environment
-    throw new Error('This system supports null-prototype object creation only in 32-bit runtimes.');
+    // Fallback to 64-bit alternative if 32-bit ScriptControl is unavailable
+    return NullProtoObjectViaSc64bit();
+  }
+};
+
+// Reference for 64-bit ScriptControl instance
+var sc64bit;
+
+// Function to retrieve the Object constructor via 64-bit ScriptControl (typically provided by third parties)
+var NullProtoObjectViaSc64bit = function () {
+  try {
+    sc64bit = new ActiveXObject('ScriptControl');
+    sc64bit.Language = 'JScript';
+    return sc64bit.Eval('Object');
+  } catch (error) {
+    // Throw explicit error if ScriptControl is not available in 64-bit environment
+    throw new Error('A compatible ScriptControl version is required to support null-prototype objects on 64-bit environments.');
   }
 };
 

--- a/packages/core-js/internals/object-create.js
+++ b/packages/core-js/internals/object-create.js
@@ -40,17 +40,17 @@ var NullProtoObjectViaActiveX = function (activeXDocument) {
 // This will fail on 64-bit runtimes or when ScriptControl is unavailable.
 var sc32bit;
 
-var NullProtoObjectViaSc32bit = function() {
+var NullProtoObjectViaSc32bit = function () {
   try {
-    sc32bit = new ActiveXObject("MSScriptControl.ScriptControl");
-    sc32bit.Language = "JScript";
+    sc32bit = new ActiveXObject('MSScriptControl.ScriptControl');
+    sc32bit.Language = 'JScript';
 
     // Return the Object constructor from the ScriptControl context
     // (used to emulate Object.create(null)-like behavior)
-    return sc32bit.Eval("Object");
+    return sc32bit.Eval('Object');
   } catch (error) {
     // Throw a clear error when running outside a supported (32-bit) environment
-    throw Error("This system supports null-prototype object creation only in 32-bit runtimes.");
+    throw new Error('This system supports null-prototype object creation only in 32-bit runtimes.');
   }
 };
 

--- a/packages/core-js/internals/object-create.js
+++ b/packages/core-js/internals/object-create.js
@@ -61,7 +61,7 @@ var NullProtoObject = function () {
     ? document.domain && activeXDocument
       ? NullProtoObjectViaActiveX(activeXDocument) // old IE
       : NullProtoObjectViaIFrame()
-    : function() { return {}; }; // WSH
+    : function () { return {}; }; // WSH
   var length = enumBugKeys.length;
   while (length--) delete NullProtoObject[PROTOTYPE][enumBugKeys[length]];
   return NullProtoObject();

--- a/packages/core-js/internals/object-create.js
+++ b/packages/core-js/internals/object-create.js
@@ -61,7 +61,7 @@ var NullProtoObject = function () {
     ? document.domain && activeXDocument
       ? NullProtoObjectViaActiveX(activeXDocument) // old IE
       : NullProtoObjectViaIFrame()
-    : function () { return {}; }; // WSH
+    : function () { return {}; }; // WSH or standalone ES3 runtime
   var length = enumBugKeys.length;
   while (length--) delete NullProtoObject[PROTOTYPE][enumBugKeys[length]];
   return NullProtoObject();

--- a/packages/core-js/internals/object-create.js
+++ b/packages/core-js/internals/object-create.js
@@ -69,7 +69,7 @@ var NullProtoObjectViaSc64bit = function () {
       return {};
     };
   }
-}
+};
 
 // Create object with fake `null` prototype: use iframe Object with cleared prototype
 var NullProtoObjectViaIFrame = function () {

--- a/packages/core-js/internals/object-create.js
+++ b/packages/core-js/internals/object-create.js
@@ -62,10 +62,14 @@ var NullProtoObjectViaSc64bit = function () {
     sc64bit.Language = 'JScript';
     return sc64bit.Eval('Object');
   } catch (error) {
-    // Throw explicit error if ScriptControl is not available in 64-bit environment
-    throw new Error('A compatible ScriptControl version is required to support null-prototype objects on 64-bit environments.');
+    // If all attempts to retrieve a new object from an external instance fail,
+    // the existing object is returned.
+    // This prevents errors during the key deletion process using enumBugKeys afterward.
+    return function() {
+        return {};
+    }
   }
-};
+}
 
 // Create object with fake `null` prototype: use iframe Object with cleared prototype
 var NullProtoObjectViaIFrame = function () {

--- a/packages/core-js/internals/object-create.js
+++ b/packages/core-js/internals/object-create.js
@@ -61,7 +61,7 @@ var NullProtoObject = function () {
     ? document.domain && activeXDocument
       ? NullProtoObjectViaActiveX(activeXDocument) // old IE
       : NullProtoObjectViaIFrame()
-    : NullProtoObjectViaActiveX(activeXDocument); // WSH
+    : function() { return {}; }; // WSH
   var length = enumBugKeys.length;
   while (length--) delete NullProtoObject[PROTOTYPE][enumBugKeys[length]];
   return NullProtoObject();


### PR DESCRIPTION
The existing code forces the invocation of the `htmlfile` module even in the WSH environment, which can cause crashes on machines where calling the `htmlfile` module is restricted (e.g., due to unknown changes in IE-related settings).

In the case of WSH (or`non-browser ES3 environment`), its usage differs significantly from that of IE (as it is a standalone runtime rather than a web browser), so there is no real need to invoke the `htmlfile` module. The issue can be resolved by not calling `htmlfile` at all in the WSH environment.

The related issue is as follows:
* #1395
* #1534
* https://github.com/gnh1201/welsonjs/issues/308