### PR TITLE
Throw TypeError for non-integral Infinity size in Iterator.prototype.chunks/windows

### DIFF
--- a/packages/core-js/internals/iterator-chunk-size-validation.js
+++ b/packages/core-js/internals/iterator-chunk-size-validation.js
@@ -1,14 +1,14 @@
 'use strict';
+var isIntegralNumber = require('../internals/is-integral-number');
 var iteratorClose = require('../internals/iterator-close');
 
 var $RangeError = RangeError;
 var $TypeError = TypeError;
-var floor = Math.floor;
 
 var CHUNK_SIZE_VALIDATION_ERROR = 'Chunk size must be an integer in [1, 2^32-1]';
 
 module.exports = function (chunkSize, iterator) {
-  if (typeof chunkSize != 'number' || floor(chunkSize) !== chunkSize) {
+  if (typeof chunkSize != 'number' || !isIntegralNumber(chunkSize)) {
     return iteratorClose(iterator, 'throw', new $TypeError(CHUNK_SIZE_VALIDATION_ERROR));
   }
   if (chunkSize === 0 || chunkSize >>> 0 !== chunkSize) {

--- a/tests/unit-global/esnext.iterator.chunks.js
+++ b/tests/unit-global/esnext.iterator.chunks.js
@@ -35,6 +35,8 @@ QUnit.test('Iterator#chunks', assert => {
   assert.throws(() => chunks.call(it), TypeError, 'throws on empty argument');
   assert.throws(() => chunks.call(it, '2'), TypeError, 'throws on empty argument');
   assert.throws(() => chunks.call(it, 2.1), TypeError, 'throws on empty argument');
+  assert.throws(() => chunks.call(it, Infinity), TypeError, 'throws a TypeError on non-integral Infinity argument');
+  assert.throws(() => chunks.call(it, -Infinity), TypeError, 'throws a TypeError on non-integral -Infinity argument');
   assert.throws(() => chunks.call(it, -1), RangeError, 'throws on negative argument');
   assert.throws(() => chunks.call(it, 2 ** 32), RangeError, 'throws on negative argument');
 

--- a/tests/unit-global/esnext.iterator.windows.js
+++ b/tests/unit-global/esnext.iterator.windows.js
@@ -39,6 +39,8 @@ QUnit.test('Iterator#windows', assert => {
   assert.throws(() => windows.call(it), TypeError, 'throws on empty argument');
   assert.throws(() => windows.call(it, '2'), TypeError, 'throws on empty argument');
   assert.throws(() => windows.call(it, 2.1), TypeError, 'throws on empty argument');
+  assert.throws(() => windows.call(it, Infinity), TypeError, 'throws a TypeError on non-integral Infinity argument');
+  assert.throws(() => windows.call(it, -Infinity), TypeError, 'throws a TypeError on non-integral -Infinity argument');
   assert.throws(() => windows.call(it, -1), RangeError, 'throws on negative argument');
   assert.throws(() => windows.call(it, 2 ** 32), RangeError, 'throws on negative argument');
 

--- a/tests/unit-pure/esnext.iterator.chunks.js
+++ b/tests/unit-pure/esnext.iterator.chunks.js
@@ -34,6 +34,8 @@ QUnit.test('Iterator#chunks', assert => {
   assert.throws(() => chunks.call(it), TypeError, 'throws on empty argument');
   assert.throws(() => chunks.call(it, '2'), TypeError, 'throws on empty argument');
   assert.throws(() => chunks.call(it, 2.1), TypeError, 'throws on empty argument');
+  assert.throws(() => chunks.call(it, Infinity), TypeError, 'throws a TypeError on non-integral Infinity argument');
+  assert.throws(() => chunks.call(it, -Infinity), TypeError, 'throws a TypeError on non-integral -Infinity argument');
   assert.throws(() => chunks.call(it, -1), RangeError, 'throws on negative argument');
   assert.throws(() => chunks.call(it, 2 ** 32), RangeError, 'throws on negative argument');
 

--- a/tests/unit-pure/esnext.iterator.windows.js
+++ b/tests/unit-pure/esnext.iterator.windows.js
@@ -38,6 +38,8 @@ QUnit.test('Iterator#windows', assert => {
   assert.throws(() => windows.call(it), TypeError, 'throws on empty argument');
   assert.throws(() => windows.call(it, '2'), TypeError, 'throws on empty argument');
   assert.throws(() => windows.call(it, 2.1), TypeError, 'throws on empty argument');
+  assert.throws(() => windows.call(it, Infinity), TypeError, 'throws a TypeError on non-integral Infinity argument');
+  assert.throws(() => windows.call(it, -Infinity), TypeError, 'throws a TypeError on non-integral -Infinity argument');
   assert.throws(() => windows.call(it, -1), RangeError, 'throws on negative argument');
   assert.throws(() => windows.call(it, 2 ** 32), RangeError, 'throws on negative argument');
 


### PR DESCRIPTION
`Iterator.prototype.chunks` and `Iterator.prototype.windows` throw a `RangeError` instead of a `TypeError` when the size is a non-integral `+Infinity`/`-Infinity`.

### Repro

```js
require('core-js/actual/iterator');
[1, 2, 3].values().chunks(Infinity).next();   // RangeError, spec wants TypeError
[1, 2, 3].values().windows(-Infinity).next(); // RangeError, spec wants TypeError
```

### Root cause

The size validation used `Math.floor(chunkSize) !== chunkSize` as the integrality check. `Math.floor(Infinity) === Infinity`, so `+Infinity`/`-Infinity` pass that check and fall through to the range check `chunkSize >>> 0 !== chunkSize` (`Infinity >>> 0` is `0`), producing a `RangeError`.

### Fix

Use the canonical `isIntegralNumber` helper, which is finite-aware (`isFinite(it) && floor(it) === it`). `+Infinity`/`-Infinity` are not integral Numbers, so they now throw a `TypeError`.

### Authority

The Iterator Chunking proposal specifies, for both `chunks` and `windows`, throwing a `TypeError` when the size is not an integral Number before the `[1, 2^32-1]` `RangeError` check. ECMA-262 defines an integral Number as a finite value, so `+Infinity`/`-Infinity` are not integral and must throw a `TypeError`.

This matches the existing `2.1`/`NaN` `TypeError` behavior and leaves `-0`/`-1`/`2^32` on the `RangeError` path unchanged. Tests added to all four suites (global and pure, `chunks` and `windows`).
