### PR TITLE
Fix test helper for async iterator helpers type-definitions tests on typescript 7

### DIFF
--- a/tests/type-definitions/global/proposals/async-iterator-helpers.test.ts
+++ b/tests/type-definitions/global/proposals/async-iterator-helpers.test.ts
@@ -76,6 +76,7 @@ const r4g: Promise<string | undefined> = ains.find((v): v is string => typeof v 
 const r5: AsyncIterator<number> = ain.flatMap((v: number, i: number) => [v, v * 2]);
 const r6: Promise<void> = ain.forEach((v: number, i: number) => { });
 const r7: AsyncIterator<string> = ain.map((v: number, i: number) => v.toString());
+const r7async: AsyncIterator<string> = ain.map(async (v: number, i: number) => v.toString());
 const r8: Promise<number> = ain.reduce((acc: number, v: number, i: number) => acc + v, 0);
 const r8no: Promise<number> = ain.reduce((acc: number, v: number, i: number) => acc + v);
 const r9: Promise<boolean> = ain.some((v: number, i: number) => v > 0);

--- a/tests/type-definitions/helpers/helpers.pure.ts
+++ b/tests/type-definitions/helpers/helpers.pure.ts
@@ -59,7 +59,7 @@ interface CoreJSAsyncIteratorLike<T, TReturn = any, TNext = any> {
   find(...args: any[]): Promise<T | undefined>;
   flatMap<U>(...args: any[]): CoreJSAsyncIteratorLike<U>;
   forEach(...args: any[]): Promise<void>;
-  map<U>(...args: any[]): CoreJSAsyncIteratorLike<Awaited<U>>;
+  map<U>(callbackfn: (value: T, index: number) => U): CoreJSAsyncIteratorLike<Awaited<U>>;
   reduce<U>(...args: any[]): Promise<U>;
   some(...args: any[]): Promise<boolean>;
   take(...args: any[]): CoreJSAsyncIteratorLike<T>;

--- a/tests/type-definitions/pure/proposals/async-iterator-helpers.test.ts
+++ b/tests/type-definitions/pure/proposals/async-iterator-helpers.test.ts
@@ -63,6 +63,8 @@ const ait2 = flatMap(aiton, (v: number, i: number) => `${ v }`);
 assertCoreJSAsyncIteratorLike<string>(ait2);
 const ait3 = map(aiton, (v: number, i: number) => v * 2);
 assertCoreJSAsyncIteratorLike<number>(ait3);
+const ait3async = map(aiton, async (v: number, i: number) => `${ v }`);
+assertCoreJSAsyncIteratorLike<string>(ait3async);
 const ait4 = take(aiton, 10);
 assertCoreJSAsyncIteratorLike<number>(ait4);
 const ait5 = drop(aiton, 3);


### PR DESCRIPTION
## Problem

The type-definitions tests started failing on TypeScript 7 (only under 7.0; 6.x and 5.x were fine). All failures were TS2345 in the async iterator helpers pure test.

The cause was the `CoreJSAsyncIteratorLike` test helper. It declared `map` as `map<U>(...args: any[]): CoreJSAsyncIteratorLike<Awaited<U>>`, where `U` can't be inferred from the arguments. TypeScript 7 compares the recursive iterator types more strictly, expands the filter/flatMap/map/toArray chain, collapses that free `U` to `unknown`, and reports a false "unknown is not assignable to Awaited<U>". TypeScript 6 and below stopped the comparison earlier and accepted it.

## Fix

The fix models the helper's `map` after the real signature, so `U` is inferred from the callback's return type. This keeps `Awaited<U>` meaningful and removes the false positive without weakening the types. Also added a test for `map` with a promise-returning callback, since that behavior wasn't covered before.

Also add coverage for map with a promise-returning callback (the Awaited<U> path) in the pure and global tests.