### PR TITLE
Fix Pages build workflow broken by a stale branch

### DIFF
--- a/.github/workflows/build-and-deploy-pages.yml
+++ b/.github/workflows/build-and-deploy-pages.yml
@@ -44,14 +44,18 @@ jobs:
           ref: ${{ matrix.branch }}
       - name: Build cache key
         id: cache-key
+        env:
+          BRANCH: ${{ matrix.branch }}
         run: |
           HASH=$(git rev-parse --short HEAD)
-          echo "CACHE_KEY=${{ matrix.branch }}-$HASH" >> "$GITHUB_ENV"
+          SAFE_BRANCH="${BRANCH//\//-}"
+          echo "SAFE_BRANCH=$SAFE_BRANCH" >> "$GITHUB_ENV"
+          echo "CACHE_KEY=$SAFE_BRANCH-$HASH" >> "$GITHUB_ENV"
       - name: Restore cached artifacts
         id: artifacts-restore
         uses: actions/cache/restore@v6
         with:
-          path: ${{ matrix.branch }}
+          path: ${{ env.SAFE_BRANCH }}
           key: ${{ env.CACHE_KEY }}
       - uses: actions/setup-node@v6
         if: steps.artifacts-restore.outputs.cache-hit != 'true'
@@ -67,23 +71,23 @@ jobs:
       - name: Prepare build artifacts
         if: steps.artifacts-restore.outputs.cache-hit != 'true'
         run: |
-          mkdir -p ${{ matrix.branch }}/compat
-          cp tests/compat/index.html tests/compat/compat-data.js tests/compat/tests.js tests/compat/browsers-runner.js ${{ matrix.branch }}/compat
-          mkdir -p ${{ matrix.branch }}/bundles
-          cp tests/bundles/* ${{ matrix.branch }}/bundles
-          mkdir -p ${{ matrix.branch }}/unit-browser
-          cp tests/unit-browser/* ${{ matrix.branch }}/unit-browser
+          mkdir -p ${{ env.SAFE_BRANCH }}/compat
+          cp tests/compat/index.html tests/compat/compat-data.js tests/compat/tests.js tests/compat/browsers-runner.js ${{ env.SAFE_BRANCH }}/compat
+          mkdir -p ${{ env.SAFE_BRANCH }}/bundles
+          cp tests/bundles/* ${{ env.SAFE_BRANCH }}/bundles
+          mkdir -p ${{ env.SAFE_BRANCH }}/unit-browser
+          cp tests/unit-browser/* ${{ env.SAFE_BRANCH }}/unit-browser
       - name: Save cached artifacts
         if: steps.artifacts-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
-          path: ${{ matrix.branch }}
+          path: ${{ env.SAFE_BRANCH }}
           key: ${{ env.CACHE_KEY }}
       - name: Upload artifacts for branch ${{ matrix.branch }}
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.branch }}
-          path: ${{ matrix.branch }}
+          name: ${{ env.SAFE_BRANCH }}
+          path: ${{ env.SAFE_BRANCH }}
 
   combine-pages-and-deploy:
     needs: build-compat-pages

--- a/.github/workflows/build-and-deploy-pages.yml
+++ b/.github/workflows/build-and-deploy-pages.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           BRANCHES=$(
             git branch -r |
-            grep -Ev 'HEAD|v1|v2' |
+            grep -Ev 'HEAD|v1|v2|data-view-clamped-stage-2' |
             sed 's/^[ *]*//' |
             sed 's/^origin\///' |
             jq -R . |
@@ -32,7 +32,9 @@ jobs:
   build-compat-pages:
     needs: list-branches
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         branch: ${{ fromJson(needs.list-branches.outputs.branches) }}
     name: Build for ${{ matrix.branch }}


### PR DESCRIPTION
## Problem

The "Build and Deploy pages" workflow builds every branch in a matrix (`Build for <branch>`). The stale `data-view-clamped-stage-2` branch predates the monorepo migration and has no `prepare-monorepo` script, so its build fails with `Missing script: "prepare-monorepo"`.

Two effects made it worse:
- default `fail-fast` cancelled the healthy branch builds (master, v4,
  etc.) mid-run — they showed up as "The operation was canceled";
- the failed matrix leg marked the whole build job as failed, so
  `combine-pages-and-deploy` was skipped and Pages never deployed.

## Changes

- **Exclude `data-view-clamped-stage-2` from `list-branches`** — removes the failing leg, which is the actual root cause. The matrix goes green and the deploy runs again.
- **Sanitize branch names** — `actions/upload-artifact` rejects `/` in artifact names, so branches with a slash (feature/PR branches such as `fix/...`) failed the upload step. A `SAFE_BRANCH` with `/` replaced by `-` is now used for the artifact name, paths and cache key; the real branch name is still used for the checkout ref. Such branches now build and deploy (their pages path uses `-` instead of `/`) instead of failing.
- **`fail-fast: false`** — a broken branch no longer cancels the other branch builds.
- **`continue-on-error: true`** — a broken branch no longer fails the build job or blocks the deploy; Pages deploys from whatever built.

The last two are defensive: they keep one bad branch from breaking the whole workflow in the future.