### PR TITLE
add multi-module libraries to transpiler perf gates

### DIFF
--- a/tests/transpiler-perf/index.mjs
+++ b/tests/transpiler-perf/index.mjs
@@ -7,7 +7,12 @@
 // bundles rarely reassign at that density, and quadratic roots in the reassignment / flow
 // machinery are invisible on three.js yet catastrophic on this shape. Each transform also
 // asserts an injection happened, so a detection-dead run cannot pass vacuously fast.
-import { readFile } from 'node:fs/promises';
+//
+// A case's `source()` may also return an ARRAY of module sources, transformed one-by-one the way
+// a bundler feeds them. Those cases gate the PER-CALL axis: everything above pays setup once on a
+// huge input, so a regression in per-file work (a cache that stops being reused across calls, say)
+// is invisible there and shows up only when the same bytes arrive as hundreds of separate calls.
+import { readdir, readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { transformAsync } from '@babel/core';
@@ -64,8 +69,36 @@ function threeBuild(file) {
   return readFile(join(HERE, `node_modules/three/build/${ file }`), 'utf8');
 }
 
+// a published package carries a long tail of re-export stubs and one-line constant modules; below
+// this size a module is pure call overhead with no work to measure, which would let a bloated tail
+// drown the signal the case is meant to carry
+const TRIVIAL_MODULE_BYTES = 200;
+
+// every `.js` under the given package directories, as separate module sources
+async function packageModules(...directories) {
+  const sources = [];
+  for (const directory of directories) {
+    const base = join(HERE, 'node_modules', directory);
+    for (const file of await readdir(base, { recursive: true })) {
+      if (!file.endsWith('.js')) continue;
+      const code = await readFile(join(base, file), 'utf8');
+      if (code.length > TRIVIAL_MODULE_BYTES) sources.push(code);
+    }
+  }
+  return sources;
+}
+
+// the view-independent CodeMirror stack: editor state plus the Lezer runtime and one grammar
+const CODEMIRROR_DIRECTORIES = ['@codemirror/state/dist', '@lezer/common/dist', '@lezer/lr/dist',
+  '@lezer/highlight/dist', '@lezer/javascript/dist'];
+
 // bounds are per (mode, emitter): usage-pure REWRITES every detected use, so its budgets run
-// higher than the injection-only usage-global ones
+// higher than the injection-only usage-global ones. `injections` is the vacuous-run floor - how
+// many modules must inject. Single-source cases need their one; multi-module ones cannot demand
+// every module (a package always holds files with nothing to polyfill) but must not settle for
+// one either, or detection could die everywhere but a single module and still pass - faster, and
+// so further inside the bound. Floors sit well under the current counts: rxjs injects in 65/212
+// modules under usage-global and 47/212 under usage-pure, codemirror in 4/6 under both
 const CASES = [
   { name: 'three.core.js', source: () => threeBuild('three.core.js'), bounds: {
     'usage-global': { babel: 6, unplugin: 5 }, 'usage-pure': { babel: 8, unplugin: 5 },
@@ -88,6 +121,14 @@ const CASES = [
     'usage-global': { babel: 6, unplugin: 4 }, 'usage-pure': { babel: 6, unplugin: 4 },
   } },
   { name: 'synthetic discriminant-dense, 1600 names', source: () => syntheticDiscriminantDense(1600), ts: true, bounds: {
+    'usage-global': { babel: 6, unplugin: 4 }, 'usage-pure': { babel: 6, unplugin: 4 },
+  } },
+  // per-call axis, two granularities: rxjs spreads 233kb over ~210 tiny modules so call overhead
+  // dominates, the codemirror set puts 402kb in 6 mid-sized ones so per-file work and bytes both show
+  { name: 'rxjs esm, tiny modules', source: () => packageModules('rxjs/dist/esm'), injections: 20, bounds: {
+    'usage-global': { babel: 6, unplugin: 4 }, 'usage-pure': { babel: 6, unplugin: 4 },
+  } },
+  { name: 'codemirror + lezer, mid-sized modules', source: () => packageModules(...CODEMIRROR_DIRECTORIES), injections: 3, bounds: {
     'usage-global': { babel: 6, unplugin: 4 }, 'usage-pure': { babel: 6, unplugin: 4 },
   } },
 ];
@@ -113,17 +154,25 @@ async function transformWith(emitter, mode, source, ts) {
 }
 
 let failed = 0;
-for (const { name, source, ts = false, bounds } of CASES) {
+for (const { name, source, ts = false, injections = 1, bounds } of CASES) {
   const input = await source();
+  // single-source cases are just a one-module list; multi-module ones gate the per-call axis
+  const modules = Array.isArray(input) ? input : [input];
+  const kilobytes = Math.round(modules.reduce((total, module) => total + module.length, 0) / 1024);
   for (const mode of MODES) {
     for (const emitter of ['babel', 'unplugin']) {
       const start = performance.now();
-      const code = await transformWith(emitter, mode, input, ts);
+      let injected = 0;
+      for (const module of modules) {
+        const code = await transformWith(emitter, mode, module, ts);
+        if (code && code.includes(INJECTION_MARK[mode])) injected++;
+      }
       const seconds = (performance.now() - start) / 1000;
-      const injected = !!code && code.includes(INJECTION_MARK[mode]);
-      const ok = injected && seconds < bounds[mode][emitter];
+      const detected = injected >= injections;
+      const ok = detected && seconds < bounds[mode][emitter];
       if (!ok) failed++;
-      echo`${ ok ? green('PASS') : red('FAIL') } ${ cyan(name) } (${ Math.round(input.length / 1024) }kb) | ${ mode } ${ emitter }: ${ seconds.toFixed(2) }s (bound ${ bounds[mode][emitter] }s${ injected ? '' : ', NO INJECTION' })`;
+      const size = modules.length > 1 ? `${ kilobytes }kb, ${ modules.length } modules` : `${ kilobytes }kb`;
+      echo`${ ok ? green('PASS') : red('FAIL') } ${ cyan(name) } (${ size }) | ${ mode } ${ emitter }: ${ seconds.toFixed(2) }s (bound ${ bounds[mode][emitter] }s${ detected ? '' : `, ${ injected }/${ injections } INJECTED` })`;
     }
   }
 }

--- a/tests/transpiler-perf/package-lock.json
+++ b/tests/transpiler-perf/package-lock.json
@@ -6,7 +6,79 @@
     "": {
       "name": "tests/transpiler-perf",
       "devDependencies": {
+        "@codemirror/state": "6.7.1",
+        "@lezer/common": "1.5.2",
+        "@lezer/highlight": "1.2.3",
+        "@lezer/javascript": "1.5.4",
+        "@lezer/lr": "1.4.10",
+        "rxjs": "7.8.2",
         "three": "0.185.1"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/three": {
@@ -15,6 +87,13 @@
       "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     }
   }
 }

--- a/tests/transpiler-perf/package.json
+++ b/tests/transpiler-perf/package.json
@@ -2,6 +2,12 @@
   "name": "tests/transpiler-perf",
   "type": "module",
   "devDependencies": {
+    "@codemirror/state": "6.7.1",
+    "@lezer/common": "1.5.2",
+    "@lezer/highlight": "1.2.3",
+    "@lezer/javascript": "1.5.4",
+    "@lezer/lr": "1.4.10",
+    "rxjs": "7.8.2",
     "three": "0.185.1"
   }
 }


### PR DESCRIPTION
Every existing case feeds ONE large source, so setup is paid once and the per-call axis is unguarded: a regression in per-file work (a cache that stops being reused across calls) stays invisible there. A case's `source()` may now return an array of module sources, transformed one-by-one the way a bundler feeds them.

Two granularities, both pinned exactly like three:
- rxjs esm - 212 tiny modules, 233 kb: call overhead dominates
- @codemirror/state + @lezer/{common,lr,highlight,javascript} - 6 mid-sized modules, 402 kb: per-file work still visible, bytes too

The vacuous-run guard becomes a floor rather than a boolean. A real package always holds modules with nothing to polyfill, so "every module injects" cannot be asked for - but "at least one" would let detection die in 64 of 65 modules and still pass, faster and so further inside the bound. Each multi-module case pins a count well under its current one (rxjs injects in 65/212 modules under usage-global, 47/212 under usage-pure; codemirror 4/6), and single-source cases default to their one.

Bounds follow the existing convention (babel 6s / unplugin 4s). Measured locally at 0.4-0.8s, i.e. ~8x headroom - these stay complexity-CLASS discriminators, not constant-factor benchmarks.