### PR TITLE
fix: correct Iterator zip entry exports

### DIFF
--- a/packages/core-js/actual/iterator/zip-keyed.js
+++ b/packages/core-js/actual/iterator/zip-keyed.js
@@ -1,5 +1,5 @@
 'use strict';
-var parent = require('../../stable/iterator/zip');
+var parent = require('../../stable/iterator/zip-keyed');
 require('../../modules/esnext.iterator.chunks');
 require('../../modules/esnext.iterator.includes');
 require('../../modules/esnext.iterator.join');

--- a/packages/core-js/es/iterator/zip-keyed.js
+++ b/packages/core-js/es/iterator/zip-keyed.js
@@ -19,6 +19,6 @@ require('../../modules/es.iterator.to-array');
 require('../../modules/es.iterator.zip-keyed');
 require('../../modules/web.dom-collections.iterator');
 
-var entryUnbind = require('../../internals/entry-unbind');
+var path = require('../../internals/path');
 
-module.exports = entryUnbind('Iterator', 'zipKeyed');
+module.exports = path.Iterator.zipKeyed;

--- a/packages/core-js/es/iterator/zip.js
+++ b/packages/core-js/es/iterator/zip.js
@@ -17,6 +17,6 @@ require('../../modules/es.iterator.to-array');
 require('../../modules/es.iterator.zip');
 require('../../modules/web.dom-collections.iterator');
 
-var entryUnbind = require('../../internals/entry-unbind');
+var path = require('../../internals/path');
 
-module.exports = entryUnbind('Iterator', 'zip');
+module.exports = path.Iterator.zip;

--- a/tests/entries/unit.mjs
+++ b/tests/entries/unit.mjs
@@ -360,8 +360,10 @@ for (PATH of ['core-js-pure', 'core-js']) {
     ok(typeof load(NS, 'iterator/some') == 'function');
     ok(typeof load(NS, 'iterator/take') == 'function');
     ok(typeof load(NS, 'iterator/to-array') == 'function');
-    ok(typeof load(NS, 'iterator/zip') == 'function');
-    ok(typeof load(NS, 'iterator/zip-keyed') == 'function');
+    const iteratorZip = load(NS, 'iterator/zip');
+    ok([...iteratorZip([[1], [2]])][0][1] === 2);
+    const iteratorZipKeyed = load(NS, 'iterator/zip-keyed');
+    ok([...iteratorZipKeyed({ first: [1], second: [2] })][0].second === 2);
     ok(new (load(NS, 'suppressed-error'))(1, 2).suppressed === 2);
     ok(typeof load(NS, 'disposable-stack') == 'function');
     ok(typeof load(NS, 'disposable-stack/constructor') == 'function');


### PR DESCRIPTION
Fix the direct `es/iterator/zip` and `es/iterator/zip-keyed` entries to export the static `Iterator` methods, rather than unbinding nonexistent prototype methods. Also make `actual/iterator/zip-keyed` load its matching stable entry.

Tests:
- `npm run prepare`
- `npm run test-entries`
- `npm run bundle`
- `npm run test-unit-node`
- `npm run check`
